### PR TITLE
Fix upload workflow variables/dependencies and PyPI/Conda upload

### DIFF
--- a/.github/workflows/upload_package.yml
+++ b/.github/workflows/upload_package.yml
@@ -50,26 +50,16 @@ jobs:
         #create env vars that cannot be created above due to syntax
         VERSION=$(python setup.py --version)
         LINE_STR='{% set version = "'${VERSION}'" %}'
-        SOURCE_URL="https://pypi.io/packages/source/h/${NAME}/${NAME}-${VERSION}.tar.gz"
 
         #prepend version environment variable before writing files (preserves version of master)
         echo $LINE_STR | cat - $RECIPE_PATH > temp && mv temp $RECIPE_PATH
         
-        #download tarball from pypi for hash generation
-        sleep 15
-        pip download $SOURCE_URL --no-deps --no-binary :all:
-        
-        #use openssl to generate hash and yq to write updated hash to intermediate file
-        wget https://github.com/mikefarah/yq/releases/download/3.1.0/yq_linux_amd64 -O yq
-        chmod +x yq
-        ./yq n source.sha256 $(openssl sha256 ${NAME}-${VERSION}.tar.gz | awk '{print $2}') >> update.yaml
-
     - name: Add channels for dependencies
       env:
-        REPO: 'hop'
+        PROJECT: 'hop'
         CHANNEL: 'scimma'
       run: |
-        conda index ./$REPO  #for noarch support
+        conda index ./$PROJECT  #for noarch support
         conda config --env --add channels $CHANNEL  #for adc
         conda config --env --add channels conda-forge
 
@@ -81,5 +71,5 @@ jobs:
       run: |
         conda config --set anaconda_upload yes  #uploads on build
         anaconda login --username $CONDA_USERNAME --password $CONDA_PASSWORD
-        conda build . --user $CONDA_ORG_NAME --clobber-file update.yaml  #applies updated hash
+        conda build . --user $CONDA_ORG_NAME
         anaconda logout

--- a/.github/workflows/upload_package.yml
+++ b/.github/workflows/upload_package.yml
@@ -40,18 +40,13 @@ jobs:
         conda install -y anaconda-client conda-build
         conda install -y setuptools setuptools_scm
 
-    - name: Update recipe with version and generate hash from PyPI package
-      env:
-        #can't read source url from recipe, so generate it here:
-        NAME: 'hop-client'
-        RECIPE_PATH: 'recipe/meta.yaml'
-
+    - name: Update recipe with version variable
       run: |
-        #create env vars that cannot be created above due to syntax
         VERSION=$(python setup.py --version)
         LINE_STR='{% set version = "'${VERSION}'" %}'
+        RECIPE_PATH='recipe/meta.yaml'
 
-        #prepend version environment variable before writing files (preserves version of master)
+        #prepend version string before writing files (which would change local version from HEAD version)
         echo $LINE_STR | cat - $RECIPE_PATH > temp && mv temp $RECIPE_PATH
         
     - name: Add channels for dependencies
@@ -63,7 +58,7 @@ jobs:
         conda config --env --add channels $CHANNEL  #for adc
         conda config --env --add channels conda-forge
 
-    - name: Update recipe, build package, and upload to Anaconda
+    - name: Build package and upload to Anaconda
       env:
         CONDA_USERNAME: ${{ secrets.CONDA_USER_scimma }}
         CONDA_PASSWORD: ${{ secrets.CONDA_PW_scimma }}

--- a/.github/workflows/upload_package.yml
+++ b/.github/workflows/upload_package.yml
@@ -66,10 +66,11 @@ jobs:
 
     - name: Add channels for dependencies
       env:
-        PACK_NAME: 'scimma'
+        REPO: 'hop'
+        CHANNEL: 'scimma'
       run: |
-        conda index ./$PACK_NAME  #for noarch support
-        conda config --env --add channels $PACK_NAME  #for adc
+        conda index ./$REPO  #for noarch support
+        conda config --env --add channels $CHANNEL  #for adc
         conda config --env --add channels conda-forge
 
     - name: Update recipe, build package, and upload to Anaconda

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - adc >=0.0.3
+    - adc-streaming >=0.1.0
     - xmltodict >=0.9.0
     - dataclasses    # [py==36]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
-{% set repo_name = "scimma" %}
-{% set name = "hop-client" %}
+{% set org_name = "scimma" %}
+{% set repo_name = "hop-client" %}
 
 package:
-  name: "{{ name|lower }}"
+  name: "{{ repo_name|lower }}"
   version: {{ version }}
 
 source:
-  url: "https://pypi.io/packages/source/h/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: "c0f87a158f6ea3cd302b13fec00b81445a6edf3e4629a8744078ad120f810f69"
+  git_url: "https://github.com/{{ org_name }}/{{ repo_name }}.git"
+  git_tag: "v{{ version }}"
 
 build:
   skip: True    # [not py>=36]


### PR DESCRIPTION
## Description
This PR implements fixes to the build variables and dependencies in the conda recipe.

This PR also addresses #61, namely by separating the upload to PyPI from the upload to Conda. This allows a developer to [properly trigger](https://github.com/scimma/hop-client/actions/runs/75451315) the upload workflow without [failures](https://github.com/scimma/hop-client/runs/534766612?check_suite_focus=true) due to hash/URL mismatching. This fix removes the need for hash-checking and on-the-fly recipe editing by specifying the source URL using `git_url` and `git_tag` instead of PyPI.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
