### PR TITLE
Declare `hop` as a namespace for downstream apps

### DIFF
--- a/hop/__init__.py
+++ b/hop/__init__.py
@@ -1,3 +1,5 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # declare namespace
+
 try:
     from ._version import version as __version__
 except ImportError:


### PR DESCRIPTION

## Description

This PR modifies `__init__.py` to declare `hop` as a namespace, which allows the `hop.apps` namespace to work correctly when installed via `python setup.py install`, or possibly other installation methods.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
