### PR TITLE
Feature/add codecov

### DIFF
--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install coverage codecov pytest
-        python3 setup.py install
+        pip install .
     - name: Generate coverage file
       run: |
         coverage run -m pytest || true  # "|| true" ensures that a failed pytest doesn't halt the CI

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -15,12 +15,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install coverage codecov pytest
-        pip install .
+        pip install coverage codecov pytest pytest-cov pytest-mock pytest-console-scripts
+        pip install .[dev]
     - name: Generate coverage file
+      env:
+        PACK_NAME: 'hop'
       run: |
-        coverage run -m pytest || true  # "|| true" ensures that a failed pytest doesn't halt the CI
-        coverage xml
+        #coverage run -m pytest || true  # "|| true" ensures that a failed pytest doesn't halt the CI
+        #coverage xml
+        python -m pytest --cov-report term --cov-report xml:coverage.xml --cov $PACK_NAME
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -1,0 +1,33 @@
+name: Generate coverage and upload to Codecov
+
+on: [push, pull_request]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install coverage codecov pytest
+        python3 setup.py install
+    - name: Generate coverage file
+      run: |
+        coverage run -m pytest || true  # "|| true" ensures that a failed pytest doesn't halt the CI
+        coverage xml
+    - name: Upload results to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        file: coverage.xml # optional
+        flags: pytest # optional
+        name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+
+        

--- a/.github/workflows/upload_codecov.yml
+++ b/.github/workflows/upload_codecov.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -21,8 +21,6 @@ jobs:
       env:
         PACK_NAME: 'hop'
       run: |
-        #coverage run -m pytest || true  # "|| true" ensures that a failed pytest doesn't halt the CI
-        #coverage xml
         python -m pytest --cov-report term --cov-report xml:coverage.xml --cov $PACK_NAME
     - name: Upload results to Codecov
       uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hop Client
 
 ![](https://github.com/scimma/hop-client/workflows/build/badge.svg)
 
-[![codecov](https://codecov.io/gh/scimma/hop-client/branch/master/graph/badge.svg)](https://codecov.io/gh/scimma/hop-client)
+[![codecov](https://codecov.io/gh/scimma/hop-client/branch/add_codecov/graph/badge.svg)](https://codecov.io/gh/scimma/hop-client)
 
 **hop-client** is a pub-sub client library for Multimessenger Astrophysics.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Hop Client
 
 ![](https://github.com/scimma/hop-client/workflows/build/badge.svg)
 
+[![codecov](https://codecov.io/gh/scimma/hop-client/branch/master/graph/badge.svg)](https://codecov.io/gh/scimma/hop-client)
+
 **hop-client** is a pub-sub client library for Multimessenger Astrophysics.
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hop Client
 
 ![](https://github.com/scimma/hop-client/workflows/build/badge.svg)
 
-[![codecov](https://codecov.io/gh/scimma/hop-client/branch/add_codecov/graph/badge.svg)](https://codecov.io/gh/scimma/hop-client)
+[![codecov](https://codecov.io/gh/scimma/hop-client/branch/master/graph/badge.svg)](https://codecov.io/gh/scimma/hop-client)
 
 **hop-client** is a pub-sub client library for Multimessenger Astrophysics.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: no      # [yes :: must have a head report to post]
+  branches:               # branch names that can post comment
+    - "master"
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        base: auto
 comment:
   layout: "reach, diff, flags, files"
   behavior: default


### PR DESCRIPTION
## Description

This PR implements #46 to add code coverage CI via [Codecov](https://codecov.io/), by:  
* creating a [Codecov account](https://codecov.io/gh/scimma/hop-client) with credentials in Github secrets and a webhook to Codecov
* adding a Github Actions workflow to generate a coverage report and upload to Codecov after a push
* generating a Codecov coverage comment when making a PR
* adding a Codecov badge displaying the repo's coverage in the README
* giving a Codecov CI failure if coverage falls below 70%

(I picked the 70% coverage threshold as a general estimate, but it's flexible so let me know if something else seems reasonable)

## Checklist

* [X] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [X] Add/update sphinx documentation with any relevant changes.
* [X] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [X] `make test` runs without errors.
* [X] `make lint` doesn't give any warnings.
* [X] `make format` doesn't give any code formatting suggestions.
* [X] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
