### PR TITLE
Update dev tooling from adc-streaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ help :
 	@echo
 	@echo '  make test                  run unit tests'
 	@echo '  make lint                  run linter'
-	@echo '  make format                run code formatter, giving a diff for recommended changes'
+	@echo '  make format                run code formatter'
 	@echo '  make doc                   make documentation'
 	@echo '  make changelog             update changelog based on version'
-	@echo '  make dist                  make binary and source packages'
-	@echo '  make dist-check            verify binary and source packages'
-	@echo '  make upload                upload to PyPI'
+	@echo '  make pypi-dist             make binary and source packages for PyPI'
+	@echo '  make pypi-dist-check       verify binary and source packages for PyPI'
+	@echo '  make conda-build           make binary and source packages for conda-forge'
 	@echo
 
 VERSION ?= $(shell python setup.py --version)
@@ -18,7 +18,7 @@ REPO_URL = https://github.com/scimma/hop-client
 
 .PHONY: test
 test :
-	python setup.py test
+	python -m pytest -v --cov=hop
 
 .PHONY: lint
 lint :
@@ -29,9 +29,7 @@ lint :
 
 .PHONY: format
 format :
-	# show diff via black
-	black tests --diff
-	black hop --diff
+	autopep8 --recursive --in-place .
 
 .PHONY: doc
 doc :
@@ -42,14 +40,14 @@ changelog :
 	sed -i 's@## \[Unreleased]@## \[Unreleased]\n\n## \[$(VERSION)] - $(shell date +'%Y-%m-%d')@' CHANGELOG.md
 	sed -i 's@.*\[Unreleased]:.*@\[Unreleased]: $(REPO_URL)/compare/v$(VERSION)...HEAD\n[$(VERSION)]: $(REPO_URL)/releases/tag/v$(VERSION)@' CHANGELOG.md
 
-.PHONY: dist
-dist :
-	python setup.py sdist bdist_wheel	
+.PHONY: pypi-dist
+pypi-dist :
+	python setup.py sdist bdist_wheel
 
-.PHONY: dist-check
-dist-check:
+.PHONY: pypi-dist-check
+pypi-dist-check:
 	twine check dist/*
 
-.PHONY: upload
-upload:
-	twine upload dist/*
+.PHONY: conda-build
+conda-build:
+	conda build -c defaults -c conda-forge ./recipe

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -94,8 +94,10 @@ html_theme = 'default'
 #
 # html_theme_options = {}
 
+
 def setup(app):
     app.add_stylesheet('css/my_theme.css')
+
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/hop/models.py
+++ b/hop/models.py
@@ -86,9 +86,7 @@ class GCNCircular(object):
         return asdict(self)
 
     def __str__(self):
-        headers = [
-            (name.upper() + ":").ljust(9) + val for name, val in self.header.items()
-        ]
+        headers = [(name.upper() + ":").ljust(9) + val for name, val in self.header.items()]
         return "\n".join(headers + ["", self.body])
 
     @classmethod

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,7 @@
-[aliases]
-test = pytest
-
-[tool:pytest]
-addopts = -v --cov=hop
-
 [flake8]
+max-line-length = 110
+max-doc-length = 110
+ignore = E203, W503
 exclude =
     setup.py,
     hop/_version.py,
@@ -16,3 +13,7 @@ exclude =
 per-file-ignores =
 	__init__.py:F401,
     tests/conftest.py:E501
+
+[tool:pytest]
+log_cli = True
+log_cli_level = INFO

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,13 @@ install_requires = [
 ]
 extras_require = {
     'dev': [
+        'autopep8',
+        'flake8',
         'pytest >= 5.0, < 5.4',
         'pytest-console-scripts',
         'pytest-cov',
         'pytest-runner',
-        'flake8',
-        'flake8-black',
+        'twine',
     ],
     'docs': [
         'sphinx',
@@ -50,6 +51,7 @@ setup(
     install_requires = install_requires,
     extras_require = extras_require,
     setup_requires = ['setuptools_scm'],
+    zip_safe=False,
     use_scm_version = {
         'write_to': 'hop/_version.py'
     },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,6 @@ def test_cli_subscribe(script_runner):
 
         # verify CLI output
         assert ret.success
-        print(ret.stderr)
         assert ret.stderr == ""
 
         # verify broker url was processed

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ def test_voevent(voevent_fileobj):
 
 
 def test_gcn_circular(circular_text, circular_msg):
-    with patch("builtins.open", mock_open(read_data=circular_text)) as mock_file:
+    with patch("builtins.open", mock_open(read_data=circular_text)):
         gcn_file = "example.gcn3"
         with open(gcn_file, "r") as f:
             gcn = models.GCNCircular.from_email(f)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,10 +19,7 @@ def test_voevent(voevent_fileobj):
 
     assert voevent.Who["Date"] == "2020-03-02T02:00:09"
     assert voevent.Description == "Report of a candidate gravitational wave event"
-    assert (
-        voevent.WhereWhen["ObsDataLocation"]["ObservatoryLocation"]["id"]
-        == "LIGO Virgo"
-    )
+    assert voevent.WhereWhen["ObsDataLocation"]["ObservatoryLocation"]["id"] == "LIGO Virgo"
 
 
 def test_gcn_circular(circular_text, circular_msg):


### PR DESCRIPTION
## Description

This PR accomplishes a few tasks, mostly related to dev tooling and enumerated below:

* Update Makefile with targets from `adc-streaming`. The main thing I wanted here is the use of `autopep8` rather than `black` for code formatting, which is a bit less aggressive in its formatting and more configurable.
* Revert some of the aggressive formatting done by black in a few modules.
* Run linter/formatter to catch a few items to fix.
* Remove a print statement which was used for testing.
* Update dev extras requirement for using `autopep8`.
* Also added a `zip_safe = False` flag from adc-streaming, which tends to discourage making python eggs. Seems like a good option all around.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
