### PR TITLE
Pin version of adc-streaming

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - adc-streaming >=0.3.1
+    - adc-streaming ==0.3.1
     - xmltodict >=0.9.0
     - dataclasses    # [py==36]
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 0.3.1",
+    "adc-streaming == 0.3.1",
     "dataclasses ; python_version < '3.7'",
     "xmltodict >= 0.9.0"
 ]


### PR DESCRIPTION
adc-streaming has released an incompatible v1.0.0. We can't use it yet. A future revision will use the new API.

## Description

Just pin the version specified in setup.py and the conda recipe.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [ ] `make lint` doesn't give any warnings.
* [ ] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
