### PR TITLE
Remove/tidy up file headers and section dividers

### DIFF
--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-
 import argparse
 import signal
 
@@ -58,10 +54,6 @@ def set_up_cli():
     p = append_subparser(subparser, "version", version._main)
 
     return parser
-
-
-# ------------------------------------------------
-# -- main
 
 
 def main():

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module for auth utilities"
-
 import argparse
 import errno
 import logging

--- a/hop/cli.py
+++ b/hop/cli.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module for CLI utilities"
-
-
 def add_client_opts(parser):
     """Add general client options to an argument parser.
 

--- a/hop/io.py
+++ b/hop/io.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module for i/o utilities"
-
 from contextlib import contextmanager
 from dataclasses import dataclass
 import getpass

--- a/hop/models.py
+++ b/hop/models.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module to define common message formats"
-
-
 from dataclasses import asdict, dataclass, field
 import email
 import json

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,16 +1,6 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "tools to parse and publish messages"
-
-
 from .auth import load_auth
 from . import cli
 from . import io
-
-
-# ------------------------------------------------
-# -- main
 
 
 def _add_parser_args(parser):

--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Bryce Cousins (bfc5288@psu.edu)"
-__description__ = "tools to receive and parse messages"
-
-
 import json
 
 from .auth import load_auth
@@ -27,10 +21,6 @@ def print_message(message_model, json_dump=False):
         print(json.dumps(message_model.asdict()))
     else:
         print(str(message_model))
-
-
-# ------------------------------------------------
-# -- main
 
 
 def _add_parser_args(parser):

--- a/hop/version.py
+++ b/hop/version.py
@@ -1,9 +1,6 @@
 import pkg_resources
 import confluent_kafka
 
-__author__ = "Shereen Elsayed (s_elsayed@ucsb.edu"
-__description__ = "Print the versions of the packages that hop-client depends on"
-
 
 def print_packages_versions():
     """Print versions for the passed packages.
@@ -22,10 +19,6 @@ def get_packages():
 
     """
     return ["hop-client", "adc_streaming", "confluent_kafka", "librdkafka"]
-
-
-# ------------------------------------------------
-# -- main
 
 
 def _main(args):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "global configuration for pytest suite"
-
-
 import io
 
 import pytest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module that tests the auth utilities"
-
-
 from unittest.mock import patch, mock_open
 
 import pytest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module that tests entry points"
-
-
 from unittest.mock import patch, mock_open
 import sys
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module that tests the io utilities"
-
-
 from dataclasses import fields
 import json
 import logging

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Patrick Godwin (patrick.godwin@psu.edu)"
-__description__ = "a module that tests models"
-
-
 from unittest.mock import patch, mock_open
 
 from hop import models

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Bryce Cousins (bfc5288@psu.edu)"
-__description__ = "a module that tests subscribe utilities"
-
 import io
 import codecs
 from contextlib import redirect_stdout
@@ -13,9 +8,8 @@ import pytest
 
 from hop import subscribe
 
+
 # test the subscribe printer for each message format
-
-
 @pytest.mark.parametrize("message_format", ["voevent", "circular", "blob"])
 def test_print_message(message_format, message_parameters_dict):
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-
-__author__ = "Shereen Elsayed (s_elsayed@ucsb.edu)"
-__description__ = "Test for version command"
-
 import subprocess
 from hop import version
 


### PR DESCRIPTION
## Description

As mentioned in https://github.com/scimma/hop-client/pull/82#discussion_r447190308, these headers look a bit messy and is a bit verbose for no real benefit. I initially added these in and want to axe them. Last thing to mention is that the shebang at the top is unnecessary since these are modules and aren't going to be called as a script at any point.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
