### PR TITLE
Switch auth configuration to TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hop Client
 ## Quickstart
 
 By default, authentication is enabled, reading in configuration settings
-from `auth.conf`. The path to this configuration can be found by running
+from `config.toml`. The path to this configuration can be found by running
 `hop auth locate`. One can initialize this configuration with default
 settings by running `hop auth setup`. To disable authentication in the CLI
 client, one can run `--no-auth`.

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -10,7 +10,7 @@ Using the CLI
 -------------
 
 By default, authentication is enabled, reading in configuration settings
-from :code:`auth.conf`. The path to this configuration can be found by running
+from :code:`config.toml`. The path to this configuration can be found by running
 :code:`hop auth locate`. One can initialize this configuration with default
 settings by running :code:`hop auth setup`. To disable authentication in the CLI
 client, one can run :code:`--no-auth`.

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -18,6 +18,8 @@ logger = logging.getLogger("hop")
 SASLMethod = auth.SASLMethod
 
 
+# thin wrapper over adc's SASLAuth to define
+# different defaults used within Hopskotch
 class Auth(auth.SASLAuth):
     """Attach SASL-based authentication to a client.
 

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -44,6 +44,7 @@ class Auth(auth.SASLAuth):
         If using SSL via a self-signed cert, a path/location
         to the certificate.
     """
+
     def __init__(self, user, password, ssl=True, method=SASLMethod.SCRAM_SHA_512, **kwargs):
         super().__init__(user, password, ssl=ssl, method=method, **kwargs)
 

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -13,12 +13,6 @@ import toml
 
 from adc import auth
 
-DEFAULT_AUTH_CONFIG = """\
-[auth]
-username = "{username}"
-password = "{password}"
-"""
-
 logger = logging.getLogger("hop")
 
 SASLMethod = auth.SASLMethod
@@ -147,5 +141,5 @@ def _main(args):
 
             user = input("Username: ")
             with open(authfile, "w") as f:
-                f.write(DEFAULT_AUTH_CONFIG.format(username=user, password=getpass.getpass()))
+                toml.dump({"auth": {"username": user, "password": getpass.getpass()}}, f)
             logger.info(f"generated configuration at: {authfile}")

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -5,6 +5,7 @@ __description__ = "a module for auth utilities"
 
 import argparse
 import errno
+import getpass
 import logging
 import os
 
@@ -14,8 +15,8 @@ from adc import auth
 
 DEFAULT_AUTH_CONFIG = """\
 [auth]
-username = "username"
-password = "password"
+username = "{username}"
+password = "{password}"
 """
 
 logger = logging.getLogger("hop")
@@ -140,6 +141,10 @@ def _main(args):
         if os.path.exists(authfile) and not args.force:
             logger.warning("configuration already exists, overwrite file with --force")
         else:
+            logger.info("generating configuration with user-specified username + password")
             os.makedirs(os.path.dirname(authfile), exist_ok=True)
+
+            user = input("Username: ")
             with open(authfile, "w") as f:
-                f.write(DEFAULT_AUTH_CONFIG)
+                f.write(DEFAULT_AUTH_CONFIG.format(username=user, password=getpass.getpass()))
+            logger.info(f"generated configuration at: {authfile}")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   run:
     - python
     - adc-streaming >=1.0.0
+    - toml >= 0.9.4
     - xmltodict >=0.9.0
     - dataclasses    # [py==36]
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 install_requires = [
     "adc-streaming >= 1.0.0",
     "dataclasses ; python_version < '3.7'",
+    "toml >= 0.9.4",
     "xmltodict >= 0.9.0"
 ]
 extras_require = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,17 @@ VOEVENT_XML = """\
 
 MESSAGE_BLOB = "This is a sample blob message. It is unstructured and does not require special parsing."
 
+AUTH_CONFIG = """\
+[auth]
+username = "username"
+password = "password"
+"""
+
+
+@pytest.fixture(scope="session")
+def auth_config():
+    return AUTH_CONFIG
+
 
 @pytest.fixture(scope="session")
 def circular_text():

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,8 +11,8 @@ import pytest
 from hop import auth
 
 
-def test_load_auth():
-    with patch("builtins.open", mock_open(read_data=auth.DEFAULT_AUTH_CONFIG)) as mock_file:
+def test_load_auth(auth_config):
+    with patch("builtins.open", mock_open(read_data=auth_config)) as mock_file:
 
         # check error handling
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Description

This PR switches the configuration format from librdkafka-style conf to TOML, based on #85. In addition, the `Auth` class in `auth.py` has been modified to expose `SCRAM-SHA-512` as the default SASL mechanism. Finally, upon setup to generate a new configuration file, the user is prompted for a username and password (using `getpass.getpass()` to hide the password).

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
