### PR TITLE
Piping input into hop publish

### DIFF
--- a/hop/publish.py
+++ b/hop/publish.py
@@ -31,6 +31,13 @@ def _main(args):
             message = loader.load_file(message_file)
             s.write(message)
 
+        # check if stdin is connected to TTY device
         if not sys.stdin.isatty():
-            for message in sys.stdin.read().splitlines():
-                s.write(loader.load(message))
+            messages = sys.stdin.read().splitlines()
+
+            if messages:
+                assert args.format == io.Deserializer.BLOB.name, \
+                    "piping/redirection only allowed for BLOB formats"
+
+                for message in messages:
+                    s.write(loader.load(message))

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,3 +1,6 @@
+import sys
+
+from .auth import load_auth
 from . import cli
 from . import io
 
@@ -5,7 +8,7 @@ from . import io
 def _add_parser_args(parser):
     cli.add_client_opts(parser)
     parser.add_argument(
-        "message", metavar="MESSAGE", nargs="+", help="One or more messages to publish.",
+        "message", metavar="MESSAGE", nargs="*", help="Messages to publish.",
     )
     parser.add_argument(
         "-f",
@@ -27,3 +30,7 @@ def _main(args):
         for message_file in args.message:
             message = loader.load_file(message_file)
             s.write(message)
+
+        if not sys.stdin.isatty():
+            for message in sys.stdin.read().splitlines():
+                s.write(loader.load(message))

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,6 +1,5 @@
 import sys
 
-from .auth import load_auth
 from . import cli
 from . import io
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,7 +41,7 @@ def test_cli_publish(script_runner, message_format, message_parameters_dict):
 
         broker_url = "kafka://hostname:port/message"
         ret = script_runner.run(
-            "hop", "publish", broker_url, "-f", message_format.upper(), test_file, "--no-auth",
+            "hop", "publish", broker_url, test_file, "-f", message_format.upper(), "--no-auth",
         )
 
         # verify CLI output


### PR DESCRIPTION
## Description

This PR implements https://github.com/scimma/hop-client/issues/86, to pipe messages into `hop publish`. This allows things like:

```
cat stringlist.txt | hop publish kafka://host:port/topic
```
and also
```
hop publish kafka://host:port/topic < stringlist.txt
```

A few gotchas about this is that you need to be careful to not add keyword arguments between positional arguments, since argparse will get confused and try to process one of those keyword arguments as a message.

Another is this likely won't make sense to use for circulars due to the format of said messages. We should probably add a sanity check that disables this message format when trying to parse messages from stdin.

Finally, I don't have a good way of adding in test coverage for this, since emulating terminal input seems to be much more difficult to do than mocking a file read.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
