### PR TITLE
Consistency between CLI and python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ from `config.toml`. The path to this configuration can be found by running
 settings by running `hop auth setup`. To disable authentication in the CLI
 client, one can run `--no-auth`.
 
-#### Command Line Interface
+### Command Line Interface
 
 Publish a message:
 
@@ -64,7 +64,7 @@ hop subscribe kafka://hostname:port/gcn -s EARLIEST
 This will read messages from the gcn topic from the earliest offset
 and read messages until an end of stream (EOS) is received.
 
-#### Python API
+### Python API
 
 Publish messages:
 
@@ -72,60 +72,53 @@ Using the python API, we can publish various types of messages, including
 structured messages such as GCN Circulars and VOEvents:
 
 ```python
-    from hop import stream
-    from hop.models import GCNCircular
+from hop import stream
+from hop.models import GCNCircular
 
-    # read in a GCN circular
-    with open("path/to/circular.gcn3", "r") as f:
-        circular = GCNCircular.load(f)
+# read in a GCN circular
+with open("path/to/circular.gcn3", "r") as f:
+    circular = GCNCircular.load(f)
 
-    with stream.open("kafka://hostname:port/topic", "w") as s:
-        s.write(circular)
+with stream.open("kafka://hostname:port/topic", "w") as s:
+    s.write(circular)
 ```
 
 In addition, we can also publish unstructured messages as long as they are
 JSON serializable:
 
 ```python
-    from hop import stream
+from hop import stream
 
-    with stream.open("kafka://hostname:port/topic", "w") as s:
-        s.write({"my": "message"})
+with stream.open("kafka://hostname:port/topic", "w") as s:
+    s.write({"my": "message"})
 ```
 
-By default, authentication is enabled for the Hop broker. In order to authenticate, one
-can pass in an `Auth` instance with credentials:
+By default, authentication is enabled for the Hop broker, reading in configuration
+settings from `config.toml`. In order to modify various authentication options, one
+can configure a `Stream` instance and pass in an `Auth` instance with credentials:
 
 ```python
-    from hop import stream
-    from hop.auth import Auth
+from hop import Stream
+from hop.auth import Auth
 
-    auth = Auth("my-username", "my-password")
+auth = Auth("my-username", "my-password")
+stream = Stream(auth=auth)
 
-    with stream.open("kafka://hostname:port/topic", "w", auth=auth) as s:
-        s.write({"my": "message"})
+with stream.open("kafka://hostname:port/topic", "w") as s:
+    s.write({"my": "message"})
 ```
 
-A convenience function is also provided to read in auth configuration in the same way
-as in the CLI client:
-
-```python
-    from hop import stream
-    from hop.auth import load_auth
-
-    with stream.open("kafka://hostname:port/topic", "w", auth=load_auth()) as s:
-        s.write({"my": "message"})
-```
+To explicitly disable authentication one can set `auth=None`.
 
 Consume messages:
 
 
 ```python
-    from hop import stream
+from hop import stream
 
-    with stream.open("kafka://hostname:port/topic", "r") as s:
-        for message in s:
-             print(message)
+with stream.open("kafka://hostname:port/topic", "r") as s:
+    for message in s:
+         print(message)
 ```
 
 This will listen to the Hop broker, listening to new messages and printing them to
@@ -135,12 +128,14 @@ The `start_at` option lets you control where in the stream you can start listeni
 from. For example, if you'd like to listen to all messages stored in a topic, you can do:
 
 ```python
-    from hop import stream
-    from hop.io import StartPosition
+from hop import Stream
+from hop.io import StartPosition
 
-    with stream.open("kafka://hostname:port/topic", "r", start_at=StartPosition.EARLIEST) as s:
-        for message in s:
-             print(message)
+stream = Stream(start_at=StartPosition.EARLIEST)
+
+with stream.open("kafka://hostname:port/topic", "r") as s:
+    for message in s:
+         print(message)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ with stream.open("kafka://hostname:port/topic", "w") as s:
     s.write({"my": "message"})
 ```
 
-To explicitly disable authentication one can set `auth=None`.
+To explicitly disable authentication one can set `auth` to `False`.
 
 Consume messages:
 

--- a/doc/user/auth.rst
+++ b/doc/user/auth.rst
@@ -25,13 +25,12 @@ by setting the :code:`XDG_CONFIG_PATH` variable.
 Using Credentials
 --------------------
 
-For the CLI, authentication is enabled by default and will read credentials from the
-path resolved by :code:`hop auth locate`. In order to disable authentication, one can
-pass :code:`--no-auth` for various CLI commands.
+Authentication is enabled by default and will read credentials from the
+path resolved by :code:`hop auth locate`.
 
-For the python API, the :code:`Auth` class is provided to pass in credentials to
-a :code:`Stream` instance. This provides a similar interface to authenticating
-as with the requests library.
+For the python API, one can modify various authentication options by passing
+in an :code:`Auth` instance with credentials to a :code:`Stream` instance.
+This provides a similar interface to authenticating as with the requests library.
 
 .. code:: python
 
@@ -44,15 +43,6 @@ as with the requests library.
     with stream.open("kafka://hostname:port/topic", "w") as s:
         s.write({"my": "message"})
 
-A convenience function is also provided to read in auth configuration in the same way
-as in the CLI client:
-
-.. code:: python
-
-    from hop import Stream
-    from hop.auth import load_auth
-
-    stream = Stream(auth=load_auth())
-
-    with stream.open("kafka://hostname:port/topic", "w") as s:
-        s.write({"my": "message"})
+In order to disable authentication in the command line interface, one can
+pass :code:`--no-auth` for various CLI commands. For the python API, one
+can set :code:`auth=None`.

--- a/doc/user/auth.rst
+++ b/doc/user/auth.rst
@@ -43,6 +43,6 @@ This provides a similar interface to authenticating as with the requests library
     with stream.open("kafka://hostname:port/topic", "w") as s:
         s.write({"my": "message"})
 
-In order to disable authentication in the command line interface, one can
-pass :code:`--no-auth` for various CLI commands. For the python API, one
-can set :code:`auth=None`.
+In order to disable authentication in the command line interface, you can
+pass :code:`--no-auth` for various CLI commands. For the python API, you
+can set :code:`auth` to :code:`False`.

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -68,29 +68,22 @@ JSON serializable:
     with stream.open("kafka://hostname:port/topic", "w") as s:
         s.write({"my": "message"})
 
-By default, authentication is enabled for the Hop broker. In order to authenticate, one
-can pass in an :code:`Auth` instance with credentials:
+By default, authentication is enabled for the Hop broker, reading in configuration
+settings from :code:`config.toml`. In order to modify various authentication options, one
+can configure a :code:`Stream` instance and pass in an :code:`Auth` instance with credentials:
 
 .. code:: python
 
-    from hop import stream
+    from hop import Stream
     from hop.auth import Auth
 
     auth = Auth("my-username", "my-password")
+    stream = Stream(auth=auth)
 
-    with stream.open("kafka://hostname:port/topic", "w", auth=auth) as s:
+    with stream.open("kafka://hostname:port/topic", "w") as s:
         s.write({"my": "message"})
 
-A convenience function is also provided to read in auth configuration in the same way
-as in the CLI client:
-
-.. code:: python
-
-    from hop import stream
-    from hop.auth import load_auth
-
-    with stream.open("kafka://hostname:port/topic", "w", auth=load_auth()) as s:
-        s.write({"my": "message"})
+To explicitly disable authentication one can set :code:`auth=None`.
 
 Consume messages
 ^^^^^^^^^^^^^^^^^
@@ -116,7 +109,9 @@ from. For example, if you'd like to listen to all messages stored in a topic, yo
     from hop import stream
     from hop.io import StartPosition
 
-    with stream.open("kafka://hostname:port/topic", "r", start_at=StartPosition.EARLIEST) as s:
+    stream = Stream(start_at=StartPosition.EARLIEST)
+
+    with stream.open("kafka://hostname:port/topic", "r") as s:
         for message in s:
              print(message)
 

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -83,7 +83,7 @@ can configure a :code:`Stream` instance and pass in an :code:`Auth` instance wit
     with stream.open("kafka://hostname:port/topic", "w") as s:
         s.write({"my": "message"})
 
-To explicitly disable authentication one can set :code:`auth=None`.
+To explicitly disable authentication, one can set :code:`auth` to :code:`False`.
 
 Consume messages
 ^^^^^^^^^^^^^^^^^

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -40,8 +40,7 @@ so a shorthand is provided for using one:
         for message in s:
              print(message)
 
-Both :code:`stream.open` and :code:`Stream` can be passed with similar
-configuration options, including:
+A complete list of configurable options in :code:`Stream` are:
 
 * :code:`auth`: An :code:`auth.Auth` instance to provide authentication
 * :code:`start_at`: The message offset to start at, by passing in an :code:`io.StartPosition`

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -42,7 +42,7 @@ so a shorthand is provided for using one:
 
 A complete list of configurable options in :code:`Stream` are:
 
-* :code:`auth`: An :code:`auth.Auth` instance to provide authentication
+* :code:`auth`: A `bool` or :code:`auth.Auth` instance to provide authentication
 * :code:`start_at`: The message offset to start at, by passing in an :code:`io.StartPosition`
 * :code:`persist`: Whether to keep a long-live connection to the client beyond EOS
 

--- a/hop/io.py
+++ b/hop/io.py
@@ -41,7 +41,7 @@ class Stream(object):
         self.persist = persist
 
     @property
-    @lru_cache
+    @lru_cache(maxsize=1)
     def auth(self):
         # authentication is disabled in adc-streaming by passing None,
         # so to provide a nicer interface, we allow boolean flags as well.
@@ -63,7 +63,6 @@ class Stream(object):
                 return None
         else:
             return self._auth
-
 
     def open(self, url, mode="r", metadata=False):
         """Opens a connection to an event stream.

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,4 +1,3 @@
-from .auth import load_auth
 from . import cli
 from . import io
 
@@ -21,9 +20,8 @@ def _main(args):
     """Parse and publish messages.
 
     """
-    auth = load_auth() if not args.no_auth else None
     loader = io.Deserializer[args.format]
-    stream = io.Stream(auth=auth)
+    stream = io.Stream(auth=(not args.no_auth))
 
     with stream.open(args.url, "w") as s:
         for message_file in args.message:

--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -1,6 +1,5 @@
 import json
 
-from .auth import load_auth
 from . import cli
 from . import io
 
@@ -50,9 +49,8 @@ def _main(args):
     """Receive and parse messages.
 
     """
-    auth = load_auth() if not args.no_auth else None
     start_at = io.StartPosition[args.start_at]
-    stream = io.Stream(auth=auth, start_at=start_at, persist=args.persist)
+    stream = io.Stream(auth=(not args.no_auth), start_at=start_at, persist=args.persist)
 
     with stream.open(args.url, "r") as s:
         for message in s:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -82,7 +82,7 @@ def test_stream_read(circular_msg, circular_text):
         start_at = io.StartPosition.EARLIEST
         persist = False
 
-        stream = io.Stream(persist=persist, start_at=start_at)
+        stream = io.Stream(persist=persist, start_at=start_at, auth=False)
 
         with stream.open(broker_url1, "r") as s:
             for msg in s:
@@ -117,7 +117,7 @@ def test_stream_write(circular_msg, circular_text):
 
 
 def test_stream_open():
-    stream = io.Stream()
+    stream = io.Stream(auth=False)
 
     # verify only read/writes are allowed
     with pytest.raises(ValueError):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -82,13 +82,13 @@ def test_stream_read(circular_msg, circular_text):
         start_at = io.StartPosition.EARLIEST
         persist = False
 
-        stream = io.Stream(persist=persist)
+        stream = io.Stream(persist=persist, start_at=start_at)
 
-        with stream.open(broker_url1, "r", start_at=start_at) as s:
+        with stream.open(broker_url1, "r") as s:
             for msg in s:
                 continue
 
-        with stream.open(broker_url2, "r", start_at=start_at) as s:
+        with stream.open(broker_url2, "r") as s:
             for msg in s:
                 continue
 
@@ -102,21 +102,17 @@ def test_stream_write(circular_msg, circular_text):
         start_at = io.StartPosition.EARLIEST
         persist = False
 
-        stream = io.Stream()
+        stream = io.Stream(start_at=start_at, persist=persist, auth=auth)
 
-        # verify only 1 topic is allowed in write-mode
+        # verify only 1 topic is allowed in write mode
         with pytest.raises(ValueError):
             stream.open("kafka://localhost:9092/topic1,topic2", "w")
 
-        # check various warnings when certain settings are set
+        # verify warning is raised when groupid is set in write mode
         with pytest.warns(UserWarning):
             stream.open("kafka://group@localhost:9092/topic1", "w")
-        with pytest.warns(UserWarning):
-            stream.open(broker_url, "w", start_at=start_at)
-        with pytest.warns(UserWarning):
-            stream.open(broker_url, "w", persist=persist)
 
-        with stream.open(broker_url, "w", auth=auth) as s:
+        with stream.open(broker_url, "w") as s:
             s.write(circular_msg)
 
 


### PR DESCRIPTION
## Description

This PR provides a more consistent experience between the CLI and python API. For example, for the CLI, auth credentials were automatically loaded in from a configuration file, but one needs to explicitly pass in an `Auth` instance for the python API. This change in behavior for the two interfaces has been removed. Now, the same defaults are present in both, and a `Stream()` instance by default uses authentication.

@spenczar, while I was doing this, I was thinking about the conversation from a previous PR (https://github.com/scimma/hop-client/pull/82#discussion_r447181113) on why options can be passed in both the `Stream` constructor and for `Stream.open()`. I'm rethinking my original position and leaning towards "ya ain't gonna need it" and instead just giving the default `Stream` instance sensible defaults. So that's all gone now, we can only pass in extra configuration upon class instantiation.

There was a few extra hoops to jump through in terms of making the default behavior to provide authentication in the python API, partly to allow boolean flags or an `Auth` instance to turn on/off authentication. The other part is due to this convenience class `stream` in hop's `__init__.py`, which would try to auto-load authentication upon importing hop. I opted for an approach that lazily loads authentication upon the first call to `Stream.open()` and caches it for further reuse. It also raises an error if it couldn't load credentials to authenticate. It's a...little extra complexity but I like being able to do something like this if I don't want to change any defaults:

```python
from hop import stream

with stream.open("kafka://localhost:9092/topic", "w") as s:
    stream.write(message)
```

Finally, I updated the docs accordingly for the change in behavior for the python API.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
