### PR TITLE
hop-client 0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1] - 2020-07-24
+### Changed
+- Modify message serialization format passed through the wire to enable
+  rapid message classification.
+- Simplify API both the CLI and python API, and provide consistency
+  between both methods for publishing and subscribing to messages.
+- `Stream` now takes in various message models directly for publishing,
+   and return the appropriate message model when grabbing messages,
+   with a "catch-all" unstructured type.
+- Standardize API for message models throughout.
+- Authentication is now enabled by default for both the CLI and python
+  API. Disabling authentication now needs to be done explicitly.
+- Update options in CLI and python API to reflect `adc-streaming` 1.0
+  release.
+
+### Added
+- Add `hop version` to print out versions of hop-client dependencies.
+- Add `hop auth` for various authentication utilities, including
+  setting up configuration for configuring various authentication
+  options and showing where the default configuration location is.
+- Expose `Auth` class for providing custom configuration if not
+  reading in auth configuration from a default location.
+
+### Removed
+- Remove timeout option in subscribing to messages in CLI and
+  python API, instead will listen to messages until an end-of-stream
+  (EOS) is received. To listen to messages indefinitely, use persist
+  option.
+- Remove options to pass in Producer/Consumer configuration options
+  directly. Instead, specific options can be configured and a proper
+  method for passing in authentication is exposed.
+
 ## [0.0.5] - 2020-05-02
 ### Changed
 - Change package name from `scimma-client` to `hop-client` with
@@ -33,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial Release.
 
-[Unreleased]: https://github.com/scimma/hop-client/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/scimma/hop-client/compare/v0.1...HEAD
+[0.1]: https://github.com/scimma/hop-client/releases/tag/v0.1
 [0.0.5]: https://github.com/scimma/hop-client/releases/tag/v0.0.5
 [0.0.4]: https://github.com/scimma/hop-client/releases/tag/v0.0.4
 [0.0.2]: https://github.com/scimma/hop-client/releases/tag/v0.0.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python
-    - adc-streaming >=1.0.0
+    - adc-streaming >=1.0.2
     - toml >= 0.9.4
     - xmltodict >=0.9.0
     - dataclasses    # [py==36]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 1.0.0",
+    "adc-streaming >= 1.0.2",
     "dataclasses ; python_version < '3.7'",
     "toml >= 0.9.4",
     "xmltodict >= 0.9.0"


### PR DESCRIPTION
This PR updates the changelog and minimum version of adc-streaming to 1.0.2. See #93 for the release checklist.
