### PR TITLE
Feature/import credentials

### DIFF
--- a/doc/user/auth.rst
+++ b/doc/user/auth.rst
@@ -16,7 +16,9 @@ to authenticate.
 
 In order to generate a configuration file, one can run :code:`hop configure setup`,
 which prompts the user for a username and password to connect to Hopskotch
-to publish or subscribe to messages.
+to publish or subscribe to messages. If you have the credentials csv file, you can
+use it in the configuration file generation as 
+:code:`hop configure setup --import_cred <CREDENTIALS_FILE>` 
 
 The default location for the configuration file can be found with :code:`hop configure locate`,
 which points by default to :code:`${HOME}/.config/hop/config.toml`, but can be configured

--- a/doc/user/auth.rst
+++ b/doc/user/auth.rst
@@ -18,7 +18,7 @@ In order to generate a configuration file, one can run :code:`hop configure setu
 which prompts the user for a username and password to connect to Hopskotch
 to publish or subscribe to messages. If you have the credentials csv file, you can
 use it in the configuration file generation as 
-:code:`hop configure setup --import_cred <CREDENTIALS_FILE>` 
+:code:`hop configure setup --import <CREDENTIALS_FILE>` 
 
 The default location for the configuration file can be found with :code:`hop configure locate`,
 which points by default to :code:`${HOME}/.config/hop/config.toml`, but can be configured

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -45,6 +45,14 @@ def _add_parser_args(parser):
 
 
 def write_config_file(config_file, username, password):
+    """
+        Write configuration file for the given username and password
+
+        Args:
+            config_file: configuration file path
+            username: username at hopskotch
+            password: password at hopskotch
+    """
 
     os.makedirs(os.path.dirname(config_file), exist_ok=True)
     with open(config_file, "w") as f:
@@ -52,7 +60,15 @@ def write_config_file(config_file, username, password):
         logger.info(f"Generated configuration at: {config_file}")
 
 
-def configuration_setup(config_file, is_force, csv_file):
+def set_up_configuration(config_file, is_force, csv_file):
+    """
+        Setup configuration file
+
+        Args:
+            config_file: Configuration file path
+            is_force: True if --force option is set, otherwise False
+            csv_file: Path to csv credentials file 
+    """
 
     if os.path.exists(config_file) and not is_force:
         logger.warning("Configuration already exists, overwrite file with --force")
@@ -98,6 +114,6 @@ def _main(args):
     if args.command == "locate":
         print(config_file)
     elif args.command == "setup":
-        configuration_setup(config_file, args.force, args.import_cred)
+        set_up_configuration(config_file, args.force, args.import_cred)
     elif args.command is None:
         logger.warning("Please use any of these commands: locate or setup")

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -2,6 +2,8 @@ import argparse
 import getpass
 import logging
 import os
+import csv
+import errno
 
 import toml
 
@@ -60,14 +62,13 @@ def write_config_file(config_file, username, password):
         logger.info(f"Generated configuration at: {config_file}")
 
 
-def set_up_configuration(config_file, is_force, csv_file):
+def set_up_configuration(config_file, csv_file):
     """
         Setup configuration file
 
         Args:
             config_file: Configuration file path
-            is_force: True if --force option is set, otherwise False
-            csv_file: Path to csv credentials file 
+            csv_file: Path to csv credentials file
     """
 
     if csv_file is None:
@@ -84,7 +85,6 @@ def set_up_configuration(config_file, is_force, csv_file):
                 write_config_file(config_file, creds["username"], creds["password"])
         else:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), csv_file)
-            write_config_file(config_file, username, password)
 
 
 def _main(args):
@@ -99,9 +99,9 @@ def _main(args):
     if args.command == "locate":
         print(config_file)
     elif args.command == "setup":
-        if os.path.exists(config_file) and not is_force:
+        if os.path.exists(config_file) and not args.force:
             logger.warning("Configuration already exists, overwrite file with --force")
         else:
-            set_up_configuration(config_file, args.force, args.import_cred)
+            set_up_configuration(config_file, args.import_cred)
     elif args.command is None:
         logger.warning("Please use any of these commands: locate or setup")

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -42,7 +42,7 @@ def _add_parser_args(parser):
     )
 
     setup_subparser.add_argument(
-        "-i", "--import_cred", help="Import credentilas from CSV file",
+        "-i", "--import", dest="import_cred", help="Import credentilas from CSV file",
     )
 
 

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -70,10 +70,7 @@ def set_up_configuration(config_file, is_force, csv_file):
             csv_file: Path to csv credentials file 
     """
 
-    if os.path.exists(config_file) and not is_force:
-        logger.warning("Configuration already exists, overwrite file with --force")
-
-    elif csv_file is None:
+    if csv_file is None:
         logger.info("Generating configuration with user-specified username + password")
 
         username = input("Username: ")
@@ -102,6 +99,9 @@ def _main(args):
     if args.command == "locate":
         print(config_file)
     elif args.command == "setup":
-        set_up_configuration(config_file, args.force, args.import_cred)
+        if os.path.exists(config_file) and not is_force:
+            logger.warning("Configuration already exists, overwrite file with --force")
+        else:
+            set_up_configuration(config_file, args.force, args.import_cred)
     elif args.command is None:
         logger.warning("Please use any of these commands: locate or setup")

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -98,7 +98,6 @@ def _main(args):
     if args.command == "locate":
         print(config_file)
     elif args.command == "setup":
-        print(args)
         configuration_setup(config_file, args.force, args.import_cred)
     elif args.command is None:
         logger.warning("Please use any of these commands: locate or setup")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,8 @@ from unittest.mock import patch, mock_open
 import pytest
 
 from hop import auth
+import subprocess
+import os
 
 
 def test_load_auth(auth_config):
@@ -16,3 +18,25 @@ def test_load_auth(auth_config):
         with patch("os.path.exists") as mock_exists:
             mock_exists.return_value = True
             auth.load_auth()
+
+
+def test_setup_auth():
+
+    credentials_file = "credentials.csv"
+    username = "scimma"
+    password = "scimmapass"
+    with open(credentials_file, "w") as f:
+        f.write("username,password\n")
+        f.write(username + "," + password + "\n")
+    # check on new configuration file is written using credential file
+    result = subprocess.Popen(["hop", "configure", "setup", "--import_cred", credentials_file],
+                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output, error = result.communicate()
+    assert "Your configuration file has been written at" in output.decode("utf-8")
+    configuration_file = auth.get_auth_path()
+    cf = open(configuration_file, "r")
+    config_file_text = cf.read()
+    assert username in config_file_text
+    assert password in config_file_text
+
+    os.remove(credentials_file)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,7 +30,7 @@ def test_setup_auth():
         f.write("username,password\n")
         f.write(username + "," + password + "\n")
     # check on new configuration file is written using credential file
-    result = subprocess.Popen(["hop", "configure", "setup", "--import_cred", credentials_file],
+    result = subprocess.Popen(["hop", "configure", "setup", "--import", credentials_file],
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output, error = result.communicate()
     assert "hop : INFO : Generated configuration at:" in output.decode("utf-8")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, mock_open
 import pytest
 
 from hop import auth
+from hop import configure
 import subprocess
 import os
 
@@ -32,8 +33,8 @@ def test_setup_auth():
     result = subprocess.Popen(["hop", "configure", "setup", "--import_cred", credentials_file],
                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output, error = result.communicate()
-    assert "Your configuration file has been written at" in output.decode("utf-8")
-    configuration_file = auth.get_auth_path()
+    assert "hop : INFO : Generated configuration at:" in output.decode("utf-8")
+    configuration_file = configure.get_config_path()
     cf = open(configuration_file, "r")
     config_file_text = cf.read()
     assert username in config_file_text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,15 +29,30 @@ def test_setup_auth():
     with open(credentials_file, "w") as f:
         f.write("username,password\n")
         f.write(username + "," + password + "\n")
+
     # check on new configuration file is written using credential file
-    result = subprocess.Popen(["hop", "configure", "setup", "--import", credentials_file],
-                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    output, error = result.communicate()
+    process = subprocess.Popen(["hop", "configure", "setup", "--import", credentials_file],
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output, error = process.communicate()
     assert "hop : INFO : Generated configuration at:" in output.decode("utf-8")
     configuration_file = configure.get_config_path()
     cf = open(configuration_file, "r")
     config_file_text = cf.read()
     assert username in config_file_text
     assert password in config_file_text
-
     os.remove(credentials_file)
+
+    # hop configure setup (need --force)
+    process = subprocess.Popen(["hop", "configure", "setup"],
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output, error = process.communicate()
+    warning_message = "hop : WARNING : Configuration already exists, overwrite file with --force"
+    assert warning_message in output.decode("utf-8")
+
+
+def test_no_command_configure():
+    process = subprocess.Popen(["hop", "configure"],
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output, error = process.communicate()
+    warning_message = "hop : WARNING : Please use any of these commands: locate or setup"
+    assert warning_message in output.decode("utf-8")


### PR DESCRIPTION
## Description

Added the option `--import_cred` to `hop configure setup`. This option allows you to add credentials csv file to be used in configuration file generation

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
