### PR TITLE
Expose manual committing of messages + allow use of stream.open() without context manager

### DIFF
--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -46,6 +46,18 @@ A complete list of configurable options in :code:`Stream` are:
 * :code:`start_at`: The message offset to start at, by passing in an :code:`io.StartPosition`
 * :code:`persist`: Whether to keep a long-live connection to the client beyond EOS
 
+One doesn't have to use the context manager protocol (:code:`with` block)
+to open up a stream as long as the stream is explicitly closed afterwards:
+
+.. code:: python
+
+    from hop import stream
+
+    s = stream.open("kafka://hostname:port/topic", "r")
+    for message in s:
+         print(message)
+    s.close()
+
 So far, all examples have shown the iterator interface for reading messages from an open
 stream. But one can instead call :code:`s.read()` directly or in the case of more specialized
 workflows, may make use of extra keyword arguments to configure an open stream. For example,

--- a/hop/io.py
+++ b/hop/io.py
@@ -213,8 +213,8 @@ def _generate_group_id(n):
     return '-'.join((getpass.getuser(), rand_str))
 
 
-@dataclass
-class _Metadata:
+@dataclass(frozen=True)
+class Metadata:
     """Broker-specific metadata that accompanies a consumed message.
 
     """

--- a/hop/utils/cli.py
+++ b/hop/utils/cli.py
@@ -34,6 +34,7 @@ class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
     """Custom formatter for displaying subcommands.
 
     """
+
     def _format_action(self, action):
         # fixes spacing/indent introduced by metavar in subparser
         self._action_max_length = 20

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -191,7 +191,7 @@ def test_pack_unpack_roundtrip(message, message_parameters_dict, caplog):
 
 
 def test_metadata(mock_kafka_message):
-    metadata = io.Metadata(_raw=mock_kafka_message)
+    metadata = io.Metadata.from_message(mock_kafka_message)
 
     # verify all properties are populated and match raw message
     assert metadata._raw == mock_kafka_message

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -83,8 +83,8 @@ def test_stream_read(circular_msg, circular_text, mock_broker, mock_consumer):
         mock_instance.side_effect = mock_adc_consumer
         mock_adc_consumer.stream.return_value = [{'hey', 'you'}]
 
-        broker_url1 = "kafka://hostname:port/{topic}"
-        broker_url2 = "kafka://{group_id}@hostname:port/{topic}"
+        broker_url1 = f"kafka://hostname:port/{topic}"
+        broker_url2 = f"kafka://{group_id}@hostname:port/{topic}"
         persist = False
 
         stream = io.Stream(persist=persist, start_at=start_at, auth=False)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,7 +2,7 @@ from dataclasses import fields
 import json
 import logging
 from pathlib import Path
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import patch, MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Description

Basically, the big thing here is a rework of the internal Producer/Consumer classes used within `stream.open()`.
    
These features can be split into allowing manual committing of messages, changing the API slightly for clarity, and making it easier to hold long-lived references to an open stream.
    
1. Manual committing of messages is done by calling `mark_done()` on an open stream in read mode. To do this, you can commit the optional metadata when finished processing a message. This is similar to what's being done in adc-streaming, but since it uses confluent-kafka's `Message` type to commit messages, instead it'll hold a reference to this `Message` in an internal attributre in the `Metadata` produced that can be returned when using the Consumer..
    
2. One pattern I've seen within different projects now is to hold a long-lived reference to an open stream instance within a class, and call it occasionally. This is currently not possible for consumers since we previously just defined a function with the `@contextmanager` decorator. Instead, I reworked this a bit to not directly subclass adc-streaming's Producer and Consumer, but create new classes which hold internal references to these and define custom `__enter__` and `__exit__` methods in the internal Producer and Consumer classes. This makes it possible to hold a reference as long as you explicitly call `close()` when you're done. Another side benefit of not subclassing is that it'll make mocking easier when setting up unit tests since I can mock the internal client much easier while still testing the various methods/API calls.
    
3. Finally, the API was slightly modified. A new method in the Consumer, Consumer.read() (basically the same as adc-streaming's Consumer.stream() but renamed to not have it look like `s.stream()` which may be confusing) is used to read messages from a stream in addition to the iterator API (which is just `s.read()` without any kwargs). One can pass in the metadata kwarg here instead of stream.open() instead which is more explicit than when passing it into `stream.open()`.

Some examples:

Manual committing:
```
with stream.open("kafka://localhost:9092/my-topic", "r") as s:
    for message, meta in s.read(autocommit=False, metadata=True):
        print(message, meta)
        s.mark_done(meta)
```

No context manager:
```
s = stream.open("kafka://localhost:9092/my-topic", "r")
for message in s:
    print(s)
s.close()
```

I don't have unit tests or updated documentation yet, but wanted @spenczar's opinion on this before I take it any further. Specifically, if these changes are generally reasonable and if there are any aspects that could be improved, etc.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
