### PR TITLE
Return message content rather than Blob when unpacking messages

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -173,7 +173,7 @@ class _DeserializerMixin:
             raise ValueError("Message is incorrectly formatted")
         else:
             if format == Deserializer.BLOB.name:
-                return cls[format].value(content=content)
+                return content
             elif format in cls.__members__:
                 return cls[format].value(**content)
             else:

--- a/hop/models.py
+++ b/hop/models.py
@@ -2,10 +2,13 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field
 import email
 import json
+from typing import Any, Dict, List, Union
 
 import xmltodict
 
 from . import plugins
+
+JSONType = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
 
 @dataclass
@@ -171,11 +174,9 @@ class GCNCircular(MessageModel):
 class Blob(MessageModel):
     """Defines an unformatted message blob.
 
-    This is included to mirror the implementation of structured formats.
-
     """
 
-    content: str
+    content: JSONType
     missing_schema: bool = False
 
     def __str__(self):
@@ -202,9 +203,9 @@ class Blob(MessageModel):
 
         """
         if hasattr(blob_input, "read"):
-            return cls(blob_input.read())
+            return cls(content=blob_input.read())
         else:
-            return cls(blob_input)
+            return cls(content=blob_input)
 
 
 @plugins.register

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,7 +313,7 @@ def message_parameters_dict():
         },
         "blob": {
             "model_name": "Blob",
-            "expected_model": models.Blob,
+            "expected_model": str,
             "test_file": "example_blob.txt",
             "model_text": MESSAGE_BLOB,
         },

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -27,7 +27,7 @@ def content_mock(message_model):
 @pytest.mark.parametrize("message", [
     {"format": "voevent", "content": content_mock(VOEvent)},
     {"format": "circular", "content": content_mock(GCNCircular)},
-    {"format": "blob", "content": content_mock(Blob)},
+    {"format": "blob", "content": "this is a test message"},
     {"format": "other", "content": "other"},
     ["wrong_datatype"],
     {"wrong_key": "value"},
@@ -153,7 +153,7 @@ def test_pack(circular_msg, circular_text):
 @pytest.mark.parametrize("message", [
     {"format": "voevent", "content": content_mock(VOEvent)},
     {"format": "circular", "content": content_mock(GCNCircular)},
-    {"format": "blob", "content": content_mock(Blob)},
+    {"format": "blob", "content": "this is a test message"},
 ])
 def test_pack_unpack_roundtrip(message, message_parameters_dict, caplog):
     format = message["format"]
@@ -186,8 +186,8 @@ def test_pack_unpack_roundtrip(message, message_parameters_dict, caplog):
         assert isinstance(unpacked_msg, expected_model)
         assert unpacked_msg.asdict() == orig_message.asdict()
     else:
-        assert isinstance(unpacked_msg, Blob)
-        assert unpacked_msg.content == orig_message
+        assert isinstance(unpacked_msg, type(unpacked_msg))
+        assert unpacked_msg == orig_message
 
 
 def test_metadata(mock_kafka_message):


### PR DESCRIPTION
## Description

This PR changes the behavior of unstructured (Blob) messages when they're unpacked to return the message content rather than a Blob class to be a bit more intuitive, first noted by @shereenElSayed. To clarify, if you try to publish unstructured messages and subscribe to them, you'll get back a Blob rather than the message you originally sent which can be a bit confusing.

This also updates the tests to reflect the change and makes a few changes within the Blob class. Removed the comment about the reason for adding the Blob in the docstring, updated the type annotation for the content attribute to reflect any JSON-serializable content, and updated the `load()` method to update the content tag rather than unpacking the content into the blob (if it worked before, it is by coincidence).

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
