### PR TITLE
Improve test reliability

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -34,7 +34,7 @@ class Auth(auth.SASLAuth):
         super().__init__(user, password, ssl=ssl, method=method, **kwargs)
 
 
-def load_auth(config_file=configure.get_config_path()):
+def load_auth(config_file=None):
     """Configures an Auth instance given a configuration file.
 
     Args:
@@ -48,6 +48,8 @@ def load_auth(config_file=configure.get_config_path()):
         KeyError: An error occurred parsing the configuration file.
 
     """
+    if config_file is None:
+        config_file = configure.get_config_path()
     if not os.path.exists(config_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), config_file)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,9 +20,9 @@ def test_cli_hop(script_runner):
 
 @pytest.mark.parametrize("message_format", ["voevent", "circular", "blob"])
 def test_cli_publish(script_runner, message_format, message_parameters_dict):
-    if sys.version_info < (3, 7):
+    if sys.version_info < (3, 7, 4):
         if message_format == "voevent":
-            pytest.skip("requires python3.7 or higher")
+            pytest.skip("requires python3.7.4 or higher")
 
     ret = script_runner.run("hop", "publish", "--help")
     assert ret.success


### PR DESCRIPTION
Perform auth tests in temporary directories to avoid state leaking in
from the user's home directory. Fine-tune the version requirement to
avoid the mock_file.read() bug.

## Description

Fixes #108 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] ~Add/update sphinx documentation with any relevant changes.~
* [ ] ~Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.~
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [ ] ~`make doc` runs without errors and generated docs render correctly.~
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

