### PR TITLE
Show short error messages to users by default

### DIFF
--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -1,5 +1,7 @@
 import argparse
 import signal
+import sys
+import traceback
 
 from . import __version__
 from . import configure
@@ -20,6 +22,11 @@ def set_up_cli():
     parser = argparse.ArgumentParser(prog="hop", formatter_class=cli_utils.SubcommandHelpFormatter)
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s version {__version__}",
+    )
+
+    parser.add_argument(
+        "-d", "--debug", action="store_true",
+        help="Display more verbose errors with internal details",
     )
 
     # set up subparser
@@ -51,7 +58,14 @@ def main():
 
     parser = set_up_cli()
     args = parser.parse_args()
-    args.func(args)
+    try:
+        args.func(args)
+    except Exception as ex:
+        if args.debug:
+            traceback.print_exc(file=sys.stderr)
+        else:
+            print(parser.prog + ":", ex, file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,3 +92,16 @@ def test_cli_version(script_runner):
     ret = script_runner.run("hop", "version")
     assert ret.success
     assert ret.stderr == ""
+
+
+def test_error_verbosity(script_runner):
+    simple = script_runner.run("hop", "subscribe", "BAD-URL")
+    assert not simple.success
+    assert simple.stdout == ""
+    assert "Traceback (most recent call last)" not in simple.stderr
+    assert simple.stderr.startswith("hop: ")
+
+    detailed = script_runner.run("hop", "--debug", "subscribe", "BAD-URL")
+    assert not detailed.success
+    assert detailed.stdout == ""
+    assert "Traceback (most recent call last)" in detailed.stderr


### PR DESCRIPTION
Introduce a 'debug' option to show full error stack traces.

## Description

Internal stack traces are generally not useful to end users. This patch reduces error messages, by default, down to a more traditional unix error format, i.e. `hop: error message`, but includes an option to get the full output for debugging. 

## Checklist

* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.