### PR TITLE
Provide a clear error when no topic is specified

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -90,6 +90,8 @@ class Stream(object):
         logger.debug("connecting to addresses=%s  group_id=%s  topics=%s",
                      broker_addresses, group_id, topics)
 
+        if topics is None:
+            raise ValueError("no topic(s) specified in kafka URL")
         if mode == "w":
             if len(topics) != 1:
                 raise ValueError("must specify exactly one topic in write mode")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -127,8 +127,19 @@ def test_stream_open():
     stream = io.Stream(auth=False)
 
     # verify only read/writes are allowed
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as err:
         stream.open("kafka://localhost:9092/topic1", "q")
+    assert "mode must be either 'w' or 'r'" in err.value.args
+
+    # verify that URLs with no scheme are rejected
+    with pytest.raises(ValueError) as err:
+        stream.open("bad://exmple.com/topic", "r")
+    assert "invalid kafka URL: must start with 'kafka://'" in err.value.args
+
+    # verify that URLs with no topic are rejected
+    with pytest.raises(ValueError) as err:
+        stream.open("kafka://exmple.com/", "r")
+    assert "no topic(s) specified in kafka URL" in err.value.args
 
 
 def test_unpack(circular_msg, circular_text):


### PR DESCRIPTION
This avoids failing with an error of "'NoneType' object is not iterable" which doesn't explain the actual problem to the user.

## Description

This should help inform users who are unfamiliar with Kafka that they must specify a topic, although helping them find the topic they want is a separate, larger problem. 

## Checklist

* [ ] ~All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [ ] ~Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [ ] ~`make doc` runs without errors and generated docs render correctly.~
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
