### PR TITLE
Target specific files and directories in make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,18 @@ REPO_URL = https://github.com/scimma/hop-client
 
 .PHONY: test
 test :
-	python -m pytest -v --cov=hop
+	python -m pytest -v --cov=hop tests
 
 .PHONY: lint
 lint :
 	# stop the build if there are Python syntax errors or undefined names
-	flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+	flake8 hop tests setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
 	# exit-zero treats all errors as warnings
-	flake8 . --count --exit-zero --max-complexity=12 --max-line-length=100 --statistics
+	flake8 hop tests setup.py --count --exit-zero --max-complexity=12 --max-line-length=100 --statistics
 
 .PHONY: format
 format :
-	autopep8 --recursive --in-place .
+	autopep8 --recursive --in-place hop tests setup.py
 
 .PHONY: doc
 doc :


### PR DESCRIPTION
This prevents the test, format, and lint targets from analyzing
unversioned files which are present in the same directory, like
packages installed in a virtualenv.

## Description

This might be a matter of taste, but I find it handy to have the working copy be the same directory as a virtualenv, but without this change flake8 takes in excess of 20 CPU minutes as it struggles to process the half million lines of dependencies. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* ~[ ] Add/update sphinx documentation with any relevant changes.~
* ~[ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.~
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.
