### PR TITLE
Add tests for the main functions in hop.configure

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,51 @@
+import pytest
+import os
+from unittest.mock import patch, MagicMock
+
+from hop import configure
+
+
+def check_config_file(config_path, username, password):
+    assert os.path.exists(config_path)
+    cf = open(config_path, "r")
+    config_file_text = cf.read()
+    assert username in config_file_text
+    assert password in config_file_text
+
+
+def test_write_config_file(tmpdir):
+    config_file = tmpdir + "/config"
+    username = "scimma"
+    password = "scimmapass"
+    configure.write_config_file(config_file, username, password)
+    check_config_file(config_file, username, password)
+
+
+def test_set_up_configuration_interactive(tmpdir):
+    config_file = tmpdir + "/config"
+    username = "scimma"
+    password = "scimmapass"
+    with patch("getpass.getpass", MagicMock(return_value=password)), \
+            patch("hop.configure.input", MagicMock(return_value=username)):
+        configure.set_up_configuration(config_file, csv_file=None)
+    check_config_file(config_file, username, password)
+
+
+def test_set_up_configuration_csv(tmpdir):
+    config_file = tmpdir + "/config"
+    csv_file = tmpdir + "/input.csv"
+    username = "scimma"
+    password = "scimmapass"
+    with open(csv_file, "w") as f:
+        f.write("username,password\n")
+        f.write(username + "," + password + "\n")
+    configure.set_up_configuration(config_file, csv_file=csv_file)
+    check_config_file(config_file, username, password)
+
+
+def test_set_up_configuration_missing_csv():
+    # send output to /dev/null, since there shouldn't be any
+    with pytest.raises(FileNotFoundError):
+        configure.set_up_configuration(
+            "/dev/null", csv_file="file_which_does_not_exist.csv"
+        )


### PR DESCRIPTION
## Description

The coverage checker still complains about hop/configure:94-98, although that code is really part of the CLI and is already exercised by that set of tests. However, if it would be preferable to convince the coverage tool, I can add some direct tests for `configure._main` as well. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* ~[ ] Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* ~[ ] `make doc` runs without errors and generated docs render correctly.~
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.
