### PR TITLE
Modify codecov configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,12 @@
 coverage:
+  precision: 2
+  range: 50..100
+  round: nearest
   status:
     project:
       default:
-        target: 70%
-        base: auto
-comment:
-  layout: "reach, diff, flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: no      # [yes :: must have a head report to post]
-  branches:               # branch names that can post comment
-    - "master"
-
+        target: auto
+        threshold: 1
+    patch:
+      default:
+        target: 90


### PR DESCRIPTION

## Description

This PR attempts to modify the codecov configuration so that codecov posts code coverage on PRs more consistently as well as changing some of the conditions for displaying warnings, errors based on how much the coverage changes from the current coverage.

## Checklist

~~* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~~
~~* [ ] Add/update sphinx documentation with any relevant changes.~~
~~* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.~~
~~* [ ] `make test` runs without errors.~~
~~* [ ] `make lint` doesn't give any warnings.~~
~~* [ ] `make format` doesn't give any code formatting suggestions.~~
~~* [ ] `make doc` runs without errors and generated docs render correctly.~~
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
