### PR TITLE
Increase test coverage for the models

### DIFF
--- a/hop/models.py
+++ b/hop/models.py
@@ -50,6 +50,7 @@ class MessageModel(ABC):
     @abstractmethod
     def load(cls, input_):
         """Create a new message model from a file object or string.
+        This base implementation has no functionality and should not be called.
 
         Args:
             input_: A file object or string.
@@ -58,7 +59,7 @@ class MessageModel(ABC):
             The message model.
 
         """
-        pass
+        raise NotImplementedError("MessageModel.load() should not be called")
 
 
 @dataclass

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,15 @@
 from unittest.mock import patch, mock_open
+import json
+import pytest
 
 from hop import models
+
+
+def test_MessageModel():
+    # derived classes must implement their own load() logic, and the base implementation has no
+    # useful functionality
+    with pytest.raises(NotImplementedError):
+        models.MessageModel.load(None)
 
 
 def test_voevent(voevent_fileobj):
@@ -17,6 +26,18 @@ def test_voevent(voevent_fileobj):
 
     # verify wrapper format is correct
     assert voevent.serialize()["format"] == "voevent"
+
+    # conversion to a string should produce valid JSON which should parse to match the original
+    # event data
+    as_string = str(voevent)
+    reparsed = json.loads(as_string)
+    assert reparsed["ivorn"] == voevent.ivorn
+    assert reparsed["role"] == voevent.role
+    assert reparsed["version"] == voevent.version
+    assert reparsed["Who"]["Date"] == voevent.Who["Date"]
+    assert reparsed["Description"] == voevent.Description
+    assert reparsed["WhereWhen"]["ObsDataLocation"]["ObservatoryLocation"]["id"] \
+        == voevent.WhereWhen["ObsDataLocation"]["ObservatoryLocation"]["id"]
 
 
 def test_gcn_circular(circular_text, circular_msg):
@@ -37,6 +58,13 @@ def test_gcn_circular(circular_text, circular_msg):
         # verify wrapper format is correct
         assert gcn.serialize()["format"] == "circular"
 
+        # conversion to a string should produce email formatted data which should parse to match the
+        # original event data
+        as_string = str(gcn)
+        reparsed = models.GCNCircular.load(as_string)
+        assert reparsed.header == gcn.header
+        assert reparsed.body == gcn.body
+
 
 def test_blob(blob_text, blob_msg):
     with patch("builtins.open", mock_open(read_data=blob_text)):
@@ -49,3 +77,23 @@ def test_blob(blob_text, blob_msg):
 
         # verify wrapper format is correct
         assert blob.serialize()["format"] == "blob"
+
+        # if the blob was holding a string, conversion to a string should just return that
+        as_string = str(blob)
+        assert as_string == blob.content
+        # round-tripping should work iff the blob was holding a string all along
+        assert models.Blob.load(as_string) == blob
+
+    # conversion to a dictionary should just result in a key 'content' under which the original
+    # contents are stored, regardless of whether the missing_schema flag is set
+    blob_ms = models.Blob("foo", True)
+    blob_ms_dict = blob_ms.asdict()
+    assert type(blob_ms_dict) is dict
+    assert blob_ms_dict["content"] == blob_ms.content
+    # if the flag was set, this should separately be include in the resulting dictionary
+    assert blob_ms_dict["missing_schema"] is True
+
+    blob_ws = models.Blob("bar")
+    blob_ws_dict = blob_ws.asdict()
+    assert type(blob_ws_dict) is dict
+    assert blob_ws_dict["content"] == blob_ws.content


### PR DESCRIPTION
## Description

This includes the tweak to MessageModel.load to tell anyone who does call it directly not to do so. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.