### PR TITLE
Change the publish CLI to treat input from stdin as JSON.

### DIFF
--- a/doc/user/commands.rst
+++ b/doc/user/commands.rst
@@ -28,9 +28,13 @@ This command allows a user to publish various structured and unstructured messag
 
 * `RFC 822 formatted GCN circular <https://gcn.gsfc.nasa.gov/gcn3_circulars.html>`_
 * An XML formatted `GCN/VOEvent notice <https://gcn.gsfc.nasa.gov/tech_describe.html>`_
-* Unstructured messages such as byte-encoded or JSON-serializable data.
+* Unstructured messages such as JSON-serializable data.
 
 Structured messages such as GCN circulars and VOEvents are published as JSON-formatted text.
+
+Unstructured messages may be piped to this command to be published. This mode of operation
+requires JSON input with individual messages separated by newlines, and the Blob format
+(`-f BLOB`) to be selected. 
 
 .. program-output:: hop publish --help
    :nostderr:

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,4 +1,5 @@
 import sys
+import json
 
 from . import cli
 from . import io
@@ -39,4 +40,4 @@ def _main(args):
                     "piping/redirection only allowed for BLOB formats"
 
                 for message in messages:
-                    s.write(loader.load(message))
+                    s.write(loader.load(json.loads(message)))

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -39,5 +39,8 @@ def _main(args):
                 assert args.format == io.Deserializer.BLOB.name, \
                     "piping/redirection only allowed for BLOB formats"
 
-                for message in messages:
-                    s.write(loader.load(json.loads(message)))
+                try:
+                    for message in messages:
+                        s.write(loader.load(json.loads(message)))
+                except json.decoder.JSONDecodeError as err:
+                    raise ValueError("Blob messages must be valid JSON") from err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch, mock_open
+from unittest.mock import patch, mock_open, MagicMock
 import sys
-
 import pytest
+from io import StringIO
+import io
 
 from hop import __version__
 
@@ -55,6 +56,50 @@ def test_cli_publish(script_runner, message_format, message_parameters_dict):
             mock_file.assert_called_with(test_file, "r")
 
         mock_stream.assert_called_with(broker_url, "w")
+
+    # test publishing from stdin
+    with patch("hop.io.Stream.open", mock_open()) as mock_stream:
+        ret = script_runner.run("hop", "publish", "-f", message_format.upper(), broker_url,
+                                stdin=io.StringIO('"message1"\n"message2"'))
+        if message_format == "blob":
+            assert ret.success
+        else:  # only the blob format is supported, others should trigger an error
+            assert not ret.success
+            assert "piping/redirection only allowed for BLOB formats" in ret.stderr
+
+
+def test_cli_publish_blob_types(mock_broker, mock_producer, mock_consumer):
+    from hop import publish, io, models
+    import json
+    args = MagicMock()
+    args.url = "kafka://hostname:port/topic"
+    args.format = io.Deserializer.BLOB.name
+    start_at = io.StartPosition.EARLIEST
+    read_url = "kafka://group@hostname:port/topic"
+
+    mock_adc_producer = mock_producer(mock_broker, "topic")
+    mock_adc_consumer = mock_consumer(mock_broker, "topic", "group")
+    msgs = ["a string", ["a", "list", "of", "values"],
+            {"a": "dict", "with": ["multiple", "values"]}]
+    for msg in msgs:
+        with patch("sys.stdin", StringIO(json.dumps(msg))) as mock_stdin, \
+                patch("hop.io.producer.Producer", return_value=mock_adc_producer), \
+                patch("hop.io.consumer.Consumer", return_value=mock_adc_consumer):
+            publish._main(args)
+
+            # each published message should be on the broker
+            expected_msg = json.dumps(models.Blob(msg).serialize()).encode("utf-8")
+            assert mock_broker.has_message("topic", expected_msg)
+
+            # reading from the broker should yield messages which match the originals
+            with io.Stream(persist=False, start_at=None, auth=False).open(read_url, "r") as s:
+                extracted_msgs = []
+                for extracted_msg in s:
+                    extracted_msgs.append(extracted_msg)
+                # there should be one new message
+                assert len(extracted_msgs) == 1
+                # and it should be the one we published
+                assert msg in extracted_msgs
 
 
 def test_cli_subscribe(script_runner):


### PR DESCRIPTION
This allows data output from `hop subscribe` to be fed back into
`hop publish`. It is a breaking change, so users of this interface,
if any exist, should be considered.

## Description

Aside from the interface change, which consists of a single additional call to `json.loads`, most of this patch rewrites the mock_broker and surrounding test code in order to test the new feature. I was unable to get the old approach using a combination of `MagicMock` and `functools.partialmethod` to do anything sensible (all writes kept vanishing into thin air), but it's possible I just made some mistake, and if so I would be happy to refactor this patch. 

## Checklist

* ~[ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes. (Should the expectation that unstructured data is JSON be called out more explicitly? Current wording hints at it.)
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.