### PR TITLE
Require that credential files have private permissions

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -52,6 +52,12 @@ def load_auth(config_file=None):
         config_file = configure.get_config_path()
     if not os.path.exists(config_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), config_file)
+    # check that the config file has suitable permissions
+    config_props = os.stat(config_file)
+    dangerous_perm_mask = 0o7077
+    if (config_props.st_mode & dangerous_perm_mask) != 0:
+        raise RuntimeError(f"{config_file} has unsafe permissions: {config_props.st_mode:o}\n"
+                           "Please correct it to 0600")
 
     # load config
     with open(config_file, "r") as f:

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -3,6 +3,7 @@ import logging
 import os
 import csv
 import errno
+import stat
 
 import toml
 
@@ -51,6 +52,7 @@ def write_config_file(config_file, username, password):
 
     os.makedirs(os.path.dirname(config_file), exist_ok=True)
     with open(config_file, "w") as f:
+        os.chmod(config_file, stat.S_IRUSR | stat.S_IWUSR)
         toml.dump({"auth": {"username": username, "password": password}}, f)
         logger.info(f"Generated configuration at: {config_file}")
 

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -51,8 +51,8 @@ def write_config_file(config_file, username, password):
     """
 
     os.makedirs(os.path.dirname(config_file), exist_ok=True)
-    with open(config_file, "w") as f:
-        os.chmod(config_file, stat.S_IRUSR | stat.S_IWUSR)
+    fd = os.open(config_file, os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR)
+    with open(fd, "w") as f:
         toml.dump({"auth": {"username": username, "password": password}}, f)
         logger.info(f"Generated configuration at: {config_file}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 from collections import defaultdict
+from contextlib import contextmanager
 import io
+import os
+import stat
 from unittest.mock import MagicMock
 
 import pytest
 
+from hop import configure
 from hop import models
 from hop.io import StartPosition
 
@@ -360,3 +364,51 @@ def message_parameters_dict():
             "model_text": MESSAGE_BLOB,
         },
     }
+
+
+@contextmanager
+def temp_environ(**vars):
+    """
+    A simple context manager for temporarily setting environment variables
+
+    Kwargs:
+        variables to be set and their values
+
+    Returns:
+        None
+    """
+    from os import environ
+    original = dict(environ)
+    os.environ.update(vars)
+    try:
+        yield  # no value needed
+    finally:
+        # restore original data
+        os.environ.clear()
+        os.environ.update(original)
+
+
+@contextmanager
+def temp_config(data, perms=stat.S_IRUSR | stat.S_IWUSR):
+    """
+    A context manager which creates a temporary config file with specified data and permissions
+
+    Args:
+        data: the data to be written to the file
+        perms: the permissions which should be set on the file.
+            The default value is to use the standard, safe permissions
+
+    Returns:
+        None
+    """
+    config_path = configure.get_config_path()
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    config_file = open(config_path, mode='w')
+    os.chmod(config_path, perms)
+    config_file.write(data)
+    config_file.close()
+    try:
+        yield  # no value needed
+    finally:
+        # remove file
+        os.remove(config_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from hop import configure
 from hop import models
 from hop.io import StartPosition
 
@@ -389,7 +388,7 @@ def temp_environ(**vars):
 
 
 @contextmanager
-def temp_config(data, perms=stat.S_IRUSR | stat.S_IWUSR):
+def temp_config(tmpdir, data, perms=stat.S_IRUSR | stat.S_IWUSR):
     """
     A context manager which creates a temporary config file with specified data and permissions
 
@@ -399,16 +398,17 @@ def temp_config(data, perms=stat.S_IRUSR | stat.S_IWUSR):
             The default value is to use the standard, safe permissions
 
     Returns:
-        None
+        The path to the config directory for hop to use this config file, as a string
     """
-    config_path = configure.get_config_path()
+
+    config_path = f"{tmpdir}/hop/config.toml"
     os.makedirs(os.path.dirname(config_path), exist_ok=True)
     config_file = open(config_path, mode='w')
     os.chmod(config_path, perms)
     config_file.write(data)
     config_file.close()
     try:
-        yield  # no value needed
+        yield str(tmpdir)
     finally:
         # remove file
         os.remove(config_path)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,4 @@
-from unittest.mock import patch, mock_open
-from contextlib import contextmanager
+from unittest.mock import patch
 
 import pytest
 
@@ -8,53 +7,7 @@ from hop import configure
 import os
 import stat
 
-
-@contextmanager
-def temp_environ(**vars):
-    """
-    A simple context manager for temporarily setting environment variables
-
-    Kwargs:
-        variables to be set and their values
-
-    Returns:
-        None
-    """
-    from os import environ
-    original = dict(environ)
-    os.environ.update(vars)
-    try:
-        yield  # no value needed
-    finally:
-        # restore original data
-        os.environ.clear()
-        os.environ.update(original)
-
-
-@contextmanager
-def temp_config(data, perms=stat.S_IRUSR | stat.S_IWUSR):
-    """
-    A context manager which creates a temporary config file with specified data and permissions
-
-    Args:
-        data: the data to be written to the file
-        perms: the permissions which should be set on the file.
-            The default value is to use the standard, safe permissions
-
-    Returns:
-        None
-    """
-    config_path = configure.get_config_path()
-    os.makedirs(os.path.dirname(config_path), exist_ok=True)
-    config_file = open(config_path, mode='w')
-    os.chmod(config_path, perms)
-    config_file.write(data)
-    config_file.close()
-    try:
-        yield  # no value needed
-    finally:
-        # remove file
-        os.remove(config_path)
+from conftest import temp_environ, temp_config
 
 
 def test_load_auth(auth_config, tmpdir):
@@ -95,55 +48,49 @@ def test_load_auth_malformed(tmpdir):
             auth.load_auth()
 
 
-def test_load_auth_options(auth_config):
-    # SSL should be used by default
-    # The default mechanism should be SCRAM_SHA_512
-    with patch("builtins.open", mock_open(read_data=auth_config)) as mock_file, \
-            patch("os.path.exists") as mock_exists, \
-            patch("hop.auth.Auth") as auth_mock:
-        auth.load_auth()
-        assert auth_mock.called_with(ssl=True)
-        from adc.auth import SASLMethod
-        assert auth_mock.called_with(mechanism=SASLMethod.SCRAM_SHA_512)
+def test_load_auth_options(auth_config, tmpdir):
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+        # SSL should be used by default
+        # The default mechanism should be SCRAM_SHA_512
+        with temp_config(auth_config), patch("hop.auth.Auth") as auth_mock:
+            auth.load_auth()
+            assert auth_mock.called_with(ssl=True)
+            from adc.auth import SASLMethod
+            assert auth_mock.called_with(mechanism=SASLMethod.SCRAM_SHA_512)
 
-    # But it should be possible to disable SSL
-    use_plaintext = """
+        # But it should be possible to disable SSL
+        use_plaintext = """
+                           [auth]
+                           username = "username"
+                           password = "password"
+                           protocol = "SASL_PLAINTEXT"
+                           """
+        with temp_config(use_plaintext), patch("hop.auth.Auth") as auth_mock:
+            auth.load_auth()
+            assert auth_mock.called_with(ssl=False)
+
+        # An SSL CA data path should be honored
+        with_ca_data = """
                        [auth]
                        username = "username"
                        password = "password"
-                       protocol = "SASL_PLAINTEXT"
+                       ssl_ca_location = "/foo/bar/baz"
                        """
-    with patch("builtins.open", mock_open(read_data=use_plaintext)) as mock_file, \
-            patch("os.path.exists") as mock_exists, \
-            patch("hop.auth.Auth") as auth_mock:
-        auth.load_auth()
-        assert auth_mock.called_with(ssl=False)
+        with temp_config(with_ca_data), patch("hop.auth.Auth") as auth_mock:
+            auth.load_auth()
+            assert auth_mock.called_with(ssl_ca_location="/foo/bar/baz")
 
-    # An SSL CA data path should be honored
-    with_ca_data = """
-                   [auth]
-                   username = "username"
-                   password = "password"
-                   ssl_ca_location = "/foo/bar/baz"
-                   """
-    with patch("builtins.open", mock_open(read_data=with_ca_data)) as mock_file, \
-            patch("os.path.exists") as mock_exists, \
-            patch("hop.auth.Auth") as auth_mock:
-        auth.load_auth()
-        assert auth_mock.called_with(ssl_ca_location="/foo/bar/baz")
-
-    # Alternate mechanisms should be honored
-    plain_mechanism = """
-                      [auth]
-                      username = "username"
-                      password = "password"
-                      mechanism = "PLAIN"
-                      """
-    with patch("builtins.open", mock_open(read_data=plain_mechanism)) as mock_file, \
-            patch("os.path.exists") as mock_exists, \
-            patch("hop.auth.Auth") as auth_mock:
-        auth.load_auth()
-        assert auth_mock.called_with(mechanism=SASLMethod.PLAIN)
+        # Alternate mechanisms should be honored
+        plain_mechanism = """
+                          [auth]
+                          username = "username"
+                          password = "password"
+                          mechanism = "PLAIN"
+                          """
+        with temp_config(plain_mechanism), \
+                patch("hop.auth.Auth") as auth_mock:
+            auth.load_auth()
+            assert auth_mock.called_with(mechanism=SASLMethod.PLAIN)
 
 
 def test_setup_auth(script_runner, tmpdir):

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -7,6 +7,7 @@ from hop import configure
 
 def check_config_file(config_path, username, password):
     assert os.path.exists(config_path)
+    assert os.stat(config_path).st_mode & 0o7777 == 0o600
     cf = open(config_path, "r")
     config_file_text = cf.read()
     assert username in config_file_text

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -143,7 +143,7 @@ def test_stream_auth(auth_config, tmpdir):
     assert s1.auth is None
 
     # turning on authentication should give an auth object with the data read from the default file
-    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)), temp_config(auth_config):
+    with temp_config(tmpdir, auth_config) as config_dir, temp_environ(XDG_CONFIG_HOME=config_dir):
         s2 = io.Stream(auth=True)
         a2 = s2.auth
         assert a2._config["sasl.username"] == "username"


### PR DESCRIPTION
Closes #124

## Description

Refuse to open config files which have over-broad permissions (and prompt the user to fix them). Also, produce config files with safe permissions by default. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
