### PR TITLE
Change how consumer group names are generated

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -32,6 +32,11 @@ class Auth(auth.SASLAuth):
 
     def __init__(self, user, password, ssl=True, method=SASLMethod.SCRAM_SHA_512, **kwargs):
         super().__init__(user, password, ssl=ssl, method=method, **kwargs)
+        self._username = user
+
+    @property
+    def username(self):
+        return self._username
 
 
 def load_auth(config_file=None):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -12,7 +12,8 @@ from conftest import temp_environ, temp_config
 
 def test_load_auth(auth_config, tmpdir):
     with temp_config(tmpdir, auth_config) as config_dir, temp_environ(XDG_CONFIG_HOME=config_dir):
-        auth.load_auth()
+        auth_data = auth.load_auth()
+        assert auth_data.username == "username"
 
 
 def test_load_auth_non_existent(auth_config, tmpdir):


### PR DESCRIPTION
When using proper authentication, prefix the group name with the credential username, instead of the local username. When a username is not available, simply use a purely random group name.

It would be cleaner to just not use a consumer group unless requested by the user, which other Kafka tools appear to support, but confluent kafka does not permit this. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.
