### PR TITLE
Add a CLI subcommand to list topics

### DIFF
--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -37,6 +37,16 @@ Consume messages
 This will read messages from the gcn topic from the earliest offset
 and read messages until an end of stream (EOS) is received.
 
+View Available Topics
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: bash
+
+    hop list-topics kafka://hostname:port/
+
+This will list all of the topics on the given server which you are currently
+authorized to read or write. 
+
 Using the Python API
 ----------------------
 

--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -8,6 +8,7 @@ from . import configure
 from . import publish
 from . import subscribe
 from . import version
+from . import list_topics
 from .utils import cli as cli_utils
 
 
@@ -49,6 +50,9 @@ def set_up_cli():
     subscribe._add_parser_args(p)
 
     p = cli_utils.append_subparser(subparser, "version", version._main)
+
+    p = cli_utils.append_subparser(subparser, "list-topics", list_topics._main)
+    list_topics._add_parser_args(p)
 
     return parser
 

--- a/hop/list_topics.py
+++ b/hop/list_topics.py
@@ -1,0 +1,47 @@
+from . import cli
+from .auth import load_auth
+from .io import _generate_group_id
+import adc.kafka
+import adc.errors
+import confluent_kafka
+
+
+def _main(args):
+    """List available topics.
+
+    """
+    group_id, broker_addresses, query_topics = adc.kafka.parse_kafka_url(args.url)
+    user_auth = None
+    if not args.no_auth:
+        user_auth = load_auth()
+    if group_id is None:
+        username = user_auth.username if hasattr(user_auth, "username") else None
+        group_id = _generate_group_id(username, 10)
+    config = {
+        "bootstrap.servers": ",".join(broker_addresses),
+        "error_cb": adc.errors.log_client_errors,
+        "group.id": group_id,
+    }
+    if user_auth is not None:
+        config.update(user_auth())
+    consumer = confluent_kafka.Consumer(config)
+    valid_topics = {}
+    if query_topics is not None:
+        for topic in query_topics:
+            topic_data = consumer.list_topics(topic=topic).topics
+            for topic in topic_data.keys():
+                if topic_data[topic].error is None:
+                    valid_topics[topic] = topic_data[topic]
+    else:
+        topic_results = consumer.list_topics().topics
+        valid_topics = {t: d for t, d in topic_results.items() if d.error is None}
+    if len(valid_topics) == 0:
+        print("No accessible topics")
+    else:
+        print("Accessible topics:")
+        for topic in sorted(valid_topics.keys()):
+            print(f" {topic}")
+
+
+def _add_parser_args(parser):
+    cli.add_client_opts(parser)


### PR DESCRIPTION
## Description

This adds a subcommand which will either list all of the accessible topics, or list the subset of requested topics which exist and are accessible. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.
