### PR TITLE
Give directions when the user has no configuration set up.

### DIFF
--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -10,6 +10,7 @@ from . import subscribe
 from . import version
 from . import list_topics
 from .utils import cli as cli_utils
+from .auth import load_auth
 
 
 def set_up_cli():
@@ -57,11 +58,34 @@ def set_up_cli():
     return parser
 
 
+def check_auth_data(prog_name):
+    """Advise the user on getting/configuring credential data
+    """
+
+    advice = """
+No valid credential data found
+You can get a credential from https://my.hop.scimma.org
+To load your credential, run `hop config setup`
+"""
+
+    try:
+        load_auth()
+    except FileNotFoundError:
+        print(advice)
+    except Exception as ex:
+        print(prog_name + ":", ex, file=sys.stderr)
+        print(advice)
+
+
 def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     parser = set_up_cli()
-    args = parser.parse_args()
+    try:
+        args = parser.parse_args()
+    except SystemExit:
+        check_auth_data(parser.prog)
+        raise
     try:
         args.func(args)
     except Exception as ex:

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -66,7 +66,12 @@ def load_auth(config_file=None):
 
     # load config
     with open(config_file, "r") as f:
-        config = toml.loads(f.read())["auth"]
+        try:
+            config = toml.loads(f.read())["auth"]
+        except KeyError:
+            raise RuntimeError("configuration file has no auth section")
+        except Exception as ex:
+            raise RuntimeError(f"configuration file is not configured correctly: {ex}")
 
     # translate config options
     ssl = True
@@ -87,7 +92,8 @@ def load_auth(config_file=None):
         else:
             mechanism = "SCRAM_SHA_512"
 
-    except KeyError:
-        raise KeyError("configuration file is not configured correctly")
+    except KeyError as ke:
+        raise RuntimeError("configuration file is not configured correctly: "
+                           f"missing auth property {ke}")
     else:
         return Auth(user, password, ssl=ssl, method=SASLMethod[mechanism], **extra_kwargs)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,6 +30,13 @@ def test_load_auth_bad_perms(auth_config, tmpdir):
             auth.load_auth()
 
 
+def test_load_auth_invalid_toml(tmpdir):
+    garbage = "KHFBGKJSBVJKbdfb ,s ,msb vks bs"
+    with temp_config(tmpdir, garbage) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(RuntimeError):
+        auth.load_auth()
+
+
 def test_load_auth_malformed(tmpdir):
     missing_username = """
                        [auth]
@@ -37,7 +44,7 @@ def test_load_auth_malformed(tmpdir):
                        extra = "stuff"
                        """
     with temp_config(tmpdir, missing_username) as config_dir, \
-            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(KeyError):
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(RuntimeError):
         auth.load_auth()
 
     missing_password = """
@@ -46,7 +53,7 @@ def test_load_auth_malformed(tmpdir):
                        extra = "stuff"
                    """
     with temp_config(tmpdir, missing_password) as config_dir, \
-            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(KeyError):
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(RuntimeError):
         auth.load_auth()
 
 


### PR DESCRIPTION
Additionally, refactor errors from `auth.load_auth` for better context.

## Description

When running without a subcommand, as users are likely to do right after installation, detect if there is no configuration or it is not valid, and give some advice on how to proceed. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* ~[ ] Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.