### PR TITLE
Change the internal representation to handle multiple credentials.

### DIFF
--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -81,12 +81,11 @@ Kafka topics, and takes the form:
 
 .. code:: bash
 
-   kafka://[groupid@]broker/topic[,topic2[,...]]
+   kafka://[username@]broker/topic[,topic2[,...]]
 
 The broker takes the form :code:`hostname[:port]` and gives the URL to connect to a
-Kafka broker. Optionally, a :code:`groupid` is provided which is used to keep track
-of which messages have been read from a topic with a given group ID. This allows a long-lived
-process reading messages to pick up where they left off after a restart, for example.
+Kafka broker. Optionally, a :code:`username` can be provided, which is used to select 
+among available credentials to use when communicating with the broker. 
 Finally, one can publish to a topic or subscribe to one or more topics to consume messages
 from.
 
@@ -106,7 +105,7 @@ A workflow to do this is shown below:
 
     from hop import stream
 
-    with stream.open("kafka://mygroup@hostname:port/topic1", "r") as s:
+    with stream.open("kafka://hostname:port/topic1", "r", "mygroup") as s:
         for message, metadata in s.read(metadata=True, autocommit=False):
              print(message, metadata.topic)
              s.mark_done(metadata)

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -3,6 +3,7 @@ from . import configure
 import os
 import errno
 import toml
+from collections import Mapping
 
 SASLMethod = auth.SASLMethod
 
@@ -109,7 +110,7 @@ def _interpret_auth_data(auth_data):
         KeyError: A required key is missing from a credential entry.
 
     """
-    if type(auth_data) is dict:
+    if isinstance(auth_data, Mapping):
         # upgrade old-style single dict configs to new-style list-of-dicts (with one item)
         auth_data = [auth_data]
 

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -64,7 +64,22 @@ def load_auth(config_file=None):
 
     """
     if config_file is None:
-        config_file = configure.get_config_path()
+        config_file = configure.get_config_path("auth")
+        # If finding data automatically, as a fallback, look to see if the auth data is in the main
+        # config in the old style.
+        if not os.path.exists(config_file):
+            main_config_file = configure.get_config_path("general")
+            if os.path.exists(main_config_file):
+                try:
+                    return load_auth(main_config_file)
+                except KeyError:
+                    # if the main config file does not contain auth data, rewrite the error into a
+                    # complaint that the auth config file does not exist, since that is what should
+                    # be fixed
+                    raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), config_file)
+            # if config.toml does not exist, continue and complain about lack of auth.toml,
+            # which is the real issue
+
     if not os.path.exists(config_file):
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), config_file)
     # check that the config file has suitable permissions
@@ -77,10 +92,26 @@ def load_auth(config_file=None):
     # load config
     with open(config_file, "r") as f:
         auth_data = toml.loads(f.read())["auth"]
-        if type(auth_data) is dict:
-            print("old-style config detected")
-            # upgrade old-style single dict configs to new-style list-of-dicts (with one item)
-            auth_data = [auth_data]
+
+    return _interpret_auth_data(auth_data)
+
+
+def _interpret_auth_data(auth_data):
+    """Configures Auth instances given data read from a configuration file.
+
+    Args:
+        auth_data: The data obtained from the top-level 'auth' TOML key
+
+    Returns:
+        A list of configured Auth instances.
+
+    Raises:
+        KeyError: A required key is missing from a credential entry.
+
+    """
+    if type(auth_data) is dict:
+        # upgrade old-style single dict configs to new-style list-of-dicts (with one item)
+        auth_data = [auth_data]
 
     auth = []
     for config in auth_data:

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -20,6 +20,8 @@ class Auth(auth.SASLAuth):
         Username to authenticate with.
     password : `str`
         Password to authenticate with.
+    host : `str`, optional
+        The name of the host for which this authentication is valid.
     ssl : `bool`, optional
         Whether to enable SSL (enabled by default).
     method : `SASLMethod`, optional
@@ -30,13 +32,19 @@ class Auth(auth.SASLAuth):
         to the certificate.
     """
 
-    def __init__(self, user, password, ssl=True, method=SASLMethod.SCRAM_SHA_512, **kwargs):
+    def __init__(self, user, password, host="", ssl=True, method=SASLMethod.SCRAM_SHA_512,
+                 **kwargs):
         super().__init__(user, password, ssl=ssl, method=method, **kwargs)
         self._username = user
+        self._hostname = host
 
     @property
     def username(self):
         return self._username
+
+    @property
+    def hostname(self):
+        return self._hostname
 
 
 def load_auth(config_file=None):
@@ -47,9 +55,11 @@ def load_auth(config_file=None):
             the default location if not given.
 
     Returns:
-        A configured Auth instance.
+        A list of configured Auth instances.
 
     Raises:
+        RuntimeError: The config file exists, but has unsafe permissions
+                      and will not be read until they are corrected.
         KeyError: An error occurred parsing the configuration file.
 
     """
@@ -66,28 +76,108 @@ def load_auth(config_file=None):
 
     # load config
     with open(config_file, "r") as f:
-        config = toml.loads(f.read())["auth"]
+        auth_data = toml.loads(f.read())["auth"]
+        if type(auth_data) is dict:
+            print("old-style config detected")
+            # upgrade old-style single dict configs to new-style list-of-dicts (with one item)
+            auth_data = [auth_data]
 
-    # translate config options
-    ssl = True
-    extra_kwargs = {}
-    try:
-        # SSL options
-        if "protocol" in config and config["protocol"] == "SASL_PLAINTEXT":
-            ssl = False
-        elif "ssl_ca_location" in config:
-            extra_kwargs["ssl_ca_location"] = config["ssl_ca_location"]
+    auth = []
+    for config in auth_data:
+        # translate config options
+        host = ""
+        ssl = True
+        extra_kwargs = {}
+        try:
+            # SSL options
+            if "protocol" in config and config["protocol"] == "SASL_PLAINTEXT":
+                ssl = False
+            elif "ssl_ca_location" in config:
+                extra_kwargs["ssl_ca_location"] = config["ssl_ca_location"]
 
-        # SASL options
-        user = config["username"]
-        password = config["password"]
+            # SASL options
+            user = config["username"]
+            password = config["password"]
 
-        if "mechanism" in config:
-            mechanism = config["mechanism"].replace("-", "_")
+            if "hostname" in config:
+                host = config["hostname"]
+
+            if "mechanism" in config:
+                mechanism = config["mechanism"].replace("-", "_")
+            else:
+                mechanism = "SCRAM_SHA_512"
+
+        except KeyError:
+            raise KeyError("configuration file is not configured correctly")
         else:
-            mechanism = "SCRAM_SHA_512"
+            auth.append(Auth(user, password, host=host, ssl=ssl, method=SASLMethod[mechanism],
+                             **extra_kwargs))
+    return auth
 
-    except KeyError:
-        raise KeyError("configuration file is not configured correctly")
-    else:
-        return Auth(user, password, ssl=ssl, method=SASLMethod[mechanism], **extra_kwargs)
+
+def select_matching_auth(creds, hostname, username=None):
+    """Selects the most appropriate credential to use when attempting to contact the given host.
+
+    Args:
+        creds: A list of configured Auth objects. These can be obtained from :meth:`load_auth`.
+        hostname: The name of the host for which to select suitable credentials.
+        username: `str`, optional
+            The name of the credential to use.
+
+    Returns:
+        A single Auth object which should be used to authenticate.
+
+    Raises:
+        RuntimeError: Too many or too few credentials matched.
+    """
+
+    matches = []
+    exact_hostname_match = False
+    inexact_hostname_match = False
+
+    for cred in creds:
+        maybe_exact_hostname_match = False
+        maybe_inexact_hostname_match = False
+        # If the credential has a hostname, we require it to match.
+        # If it doesn't, we have to assume it might suit the user's purposes.
+        if len(cred.hostname) > 0:
+            if cred.hostname != hostname:
+                continue
+            else:
+                # the hostname does match, but this credential might be rejected for other reasons
+                # so we cannot directly update the global exact_hostname_match
+                maybe_exact_hostname_match = True
+        else:
+            maybe_inexact_hostname_match = True
+
+        # If the user specified a specific username, we require that to be matched.
+        if username is not None and cred.username != username:
+            continue
+
+        matches.append(cred)
+        exact_hostname_match |= maybe_exact_hostname_match
+        inexact_hostname_match |= maybe_inexact_hostname_match
+
+    # if there were both exact and inexact matches, cull the inexact matches
+    if inexact_hostname_match and exact_hostname_match:
+        matches = [match for match in matches if match.hostname == hostname]
+
+    if len(matches) == 0:
+        err = f"No matching credential found for hostname '{hostname}'"
+        if username is not None:
+            err += f" with username '{username}'"
+        raise RuntimeError(err)
+
+    if len(matches) > 1:
+        err = f"Ambiguous credentials found for hostname '{hostname}'"
+        err += f" with username '{username}'" if username is not None \
+            else " with no username specified"
+        err += "Matched credentials:"
+        for match in matches:
+            err += f"\n  {match.username}"
+            err += " which has no associated hostname" if len(match.hostname) == 0 \
+                else f" for {match.hostname}"
+        raise RuntimeError(err)
+
+    # At this point we should have exactly one match
+    return matches[0]

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -10,14 +10,30 @@ import toml
 logger = logging.getLogger("hop")
 
 
-def get_config_path():
+def get_config_path(type: str = "general"):
     """Determines the default location for auth configuration.
 
+    Args:
+        type: The type of configuration data for which the path should be looked up.
+              Recognized types are 'general' and 'auth'.
+
     Returns:
-        The path to the authentication configuration file.
+        The path to the requested configuration file.
+
+    Raises:
+        ValueError: Unrecognized config type requested.
 
     """
-    auth_filepath = os.path.join("hop", "config.toml")
+
+    file_for_type = {
+        "general": "config.toml",
+        "auth": "auth.toml",
+    }
+
+    if type not in file_for_type:
+        raise ValueError(f"Unknown configuration type: '{type}'")
+
+    auth_filepath = os.path.join("hop", file_for_type[type])
     if "XDG_CONFIG_HOME" in os.environ:
         return os.path.join(os.getenv("XDG_CONFIG_HOME"), auth_filepath)
     else:
@@ -86,7 +102,7 @@ def _main(args):
     """Configuration utilities.
 
     """
-    config_file = get_config_path()
+    config_file = get_config_path("auth")
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s | %(name)s : %(levelname)s : %(message)s",
     )

--- a/hop/io.py
+++ b/hop/io.py
@@ -61,8 +61,8 @@ class Stream(object):
                     return load_auth()
                 except FileNotFoundError:
                     logger.error(
-                        "configuration set to True and configuration file"
-                        f"not found at {get_config_path()} to authenticate"
+                        "configuration set to True and configuration file "
+                        f"not found at {get_config_path('auth')} to authenticate"
                     )
                     raise
             else:

--- a/hop/list_topics.py
+++ b/hop/list_topics.py
@@ -18,9 +18,7 @@ def _main(args):
     if not args.no_auth:
         credentials = load_auth()
         user_auth = select_matching_auth(credentials, broker_addresses[0], username)
-    group_id = args.group_id
-    if group_id is None:
-        group_id = _generate_group_id(username, 10)
+    group_id = _generate_group_id(username, 10)
     config = {
         "bootstrap.servers": ",".join(broker_addresses),
         "error_cb": adc.errors.log_client_errors,
@@ -49,9 +47,3 @@ def _main(args):
 
 def _add_parser_args(parser):
     cli.add_client_opts(parser)
-
-    parser.add_argument(
-        "-g", "--group-id",
-        default=None,
-        help="Consumer group ID. If unset, a random ID will be generated."
-    )

--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -42,6 +42,11 @@ def _add_parser_args(parser):
              "Otherwise, will stop listening when EOS is received.",
     )
     parser.add_argument(
+        "-g", "--group-id",
+        default=None,
+        help="Consumer group ID. If unset, a random ID will be generated."
+    )
+    parser.add_argument(
         "-j", "--json", help="Request message output as raw json", action="store_true",
     )
 
@@ -53,6 +58,6 @@ def _main(args):
     start_at = io.StartPosition[args.start_at]
     stream = io.Stream(auth=(not args.no_auth), start_at=start_at, persist=args.persist)
 
-    with stream.open(args.url, "r") as s:
+    with stream.open(args.url, "r", group_id=args.group_id) as s:
         for message in s:
             print_message(message, args.json)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,7 +415,7 @@ def temp_config(tmpdir, data, perms=stat.S_IRUSR | stat.S_IWUSR):
         The path to the config directory for hop to use this config file, as a string
     """
 
-    config_path = f"{tmpdir}/hop/config.toml"
+    config_path = f"{tmpdir}/hop/auth.toml"
     os.makedirs(os.path.dirname(config_path), exist_ok=True)
     config_file = open(config_path, mode='w')
     os.chmod(config_path, perms)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,10 +168,19 @@ VOEVENT_XML = """\
 
 MESSAGE_BLOB = "This is a sample blob message. It is unstructured and does not require special parsing."
 
-AUTH_CONFIG = """\
+# This was the original configuration structure, which permitted only a single credential
+AUTH_CONFIG_LEGACY = """\
 [auth]
 username = "username"
 password = "password"
+"""
+
+# This is the new configuration structure, which contains a list of credentials
+AUTH_CONFIG = """
+auth = [{
+         username="username",
+         password="password"
+         }]
 """
 
 
@@ -291,6 +300,11 @@ def mock_kafka_message():
     message.timestamp.return_value = (0, 1234567890)
     message.key.return_value = "test-key"
     return message
+
+
+@pytest.fixture(scope="session")
+def legacy_auth_config():
+    return AUTH_CONFIG_LEGACY
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,10 +10,19 @@ import stat
 from conftest import temp_environ, temp_config
 
 
+def test_load_auth_legacy(legacy_auth_config, tmpdir):
+    with temp_config(tmpdir, legacy_auth_config) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir):
+        auth_data = auth.load_auth()
+        assert len(auth_data) == 1
+        assert auth_data[0].username == "username"
+
+
 def test_load_auth(auth_config, tmpdir):
     with temp_config(tmpdir, auth_config) as config_dir, temp_environ(XDG_CONFIG_HOME=config_dir):
         auth_data = auth.load_auth()
-        assert auth_data.username == "username"
+        assert len(auth_data) == 1
+        assert auth_data[0].username == "username"
 
 
 def test_load_auth_non_existent(auth_config, tmpdir):
@@ -30,7 +39,7 @@ def test_load_auth_bad_perms(auth_config, tmpdir):
             auth.load_auth()
 
 
-def test_load_auth_malformed(tmpdir):
+def test_load_auth_malformed_legacy(tmpdir):
     missing_username = """
                        [auth]
                        password = "password"
@@ -50,6 +59,24 @@ def test_load_auth_malformed(tmpdir):
         auth.load_auth()
 
 
+def test_load_auth_malformed(tmpdir):
+    missing_username = """
+        auth = [{extra="stuff",
+            password="password"}]
+        """
+    with temp_config(tmpdir, missing_username) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(KeyError):
+        auth.load_auth()
+
+    missing_password = """
+    auth = [{username="username",
+        extra="stuff"}]
+    """
+    with temp_config(tmpdir, missing_password) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(KeyError):
+        auth.load_auth()
+
+
 def test_load_auth_options(auth_config, tmpdir):
     # SSL should be used by default
     # The default mechanism should be SCRAM_SHA_512
@@ -61,40 +88,172 @@ def test_load_auth_options(auth_config, tmpdir):
         assert auth_mock.called_with(mechanism=SASLMethod.SCRAM_SHA_512)
 
     # But it should be possible to disable SSL
-    use_plaintext = """
-                       [auth]
-                       username = "username"
-                       password = "password"
+    use_plaintext = """auth = [{
+                       username = "username",
+                       password = "password",
                        protocol = "SASL_PLAINTEXT"
-                       """
+                       }]"""
     with temp_config(tmpdir, use_plaintext) as config_dir, \
             temp_environ(XDG_CONFIG_HOME=config_dir), patch("hop.auth.Auth") as auth_mock:
         auth.load_auth()
         assert auth_mock.called_with(ssl=False)
 
     # An SSL CA data path should be honored
-    with_ca_data = """
-                   [auth]
-                   username = "username"
-                   password = "password"
+    with_ca_data = """auth = [{
+                   username = "username",
+                   password = "password",
                    ssl_ca_location = "/foo/bar/baz"
-                   """
+                   }]"""
     with temp_config(tmpdir, with_ca_data) as config_dir, \
             temp_environ(XDG_CONFIG_HOME=config_dir), patch("hop.auth.Auth") as auth_mock:
         auth.load_auth()
         assert auth_mock.called_with(ssl_ca_location="/foo/bar/baz")
 
     # Alternate mechanisms should be honored
-    plain_mechanism = """
-                      [auth]
-                      username = "username"
-                      password = "password"
+    plain_mechanism = """auth = [{
+                      username = "username",
+                      password = "password",
                       mechanism = "PLAIN"
-                      """
+                      }]"""
     with temp_config(tmpdir, plain_mechanism) as config_dir, \
             temp_environ(XDG_CONFIG_HOME=config_dir), patch("hop.auth.Auth") as auth_mock:
         auth.load_auth()
         assert auth_mock.called_with(mechanism=SASLMethod.PLAIN)
+
+    # Associated hostnames should be included
+    with_host = """auth = [{
+                username = "username",
+                password = "password",
+                hostname = "example.com"
+                }]"""
+    with temp_config(tmpdir, with_host) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir):
+        creds = auth.load_auth()
+        assert len(creds) == 1
+        assert creds[0].hostname == "example.com"
+
+
+def test_load_auth_muliple_creds(tmpdir):
+    two_creds = """auth = [
+                    {
+                        username = "user1",
+                        password = "pass1",
+                        hostname = "host1"
+                    },
+                    {
+                        username = "user2",
+                        password = "pass2",
+                        hostname = "host2"
+                    },
+                ]"""
+    with temp_config(tmpdir, two_creds) as config_dir, temp_environ(XDG_CONFIG_HOME=config_dir):
+        creds = auth.load_auth()
+        assert len(creds) == 2
+        assert creds[0].username == "user1"
+        assert creds[0]._config["sasl.password"] == "pass1"
+        assert creds[0].hostname == "host1"
+        assert creds[1].username == "user2"
+        assert creds[1]._config["sasl.password"] == "pass2"
+        assert creds[1].hostname == "host2"
+
+
+def test_select_auth_no_match(auth_config, tmpdir):
+    no_match = "No matching credential found"
+
+    # no credentials at all
+    with pytest.raises(RuntimeError) as err:
+        selected = auth.select_matching_auth([], "example.com", "nosuchuser")
+        assert "No matching credential found for hostname 'example.com'" in err.value.args
+
+    # no match for requested hostname
+    with_host = """auth = [{
+        username = "username",
+        password = "password",
+        hostname = "example.com"
+        }]"""
+    with temp_config(tmpdir, with_host) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(RuntimeError) as err:
+        creds = auth.load_auth()
+        selected = auth.select_matching_auth(creds, "example.net")
+        assert f"{no_match} for hostname 'example.net' with username 'nosuchuser'" in err.value.args
+
+    # no match for requested username
+    with temp_config(tmpdir, auth_config) as config_dir, \
+            temp_environ(XDG_CONFIG_HOME=config_dir), pytest.raises(RuntimeError) as err:
+        creds = auth.load_auth()
+        selected = auth.select_matching_auth(creds, "example.com", "nosuchuser")
+        assert f"{no_match} for hostname 'example.com' with username 'nosuchuser'" in err.value.args
+
+
+def test_select_auth_ambiguity():
+    too_many = "Too many ambiguous credentials found"
+
+    two_vague_creds = [
+        auth.Auth("user1", "pass1"),
+        auth.Auth("user2", "pass2"),
+    ]
+
+    # given two credetials with no associated hostnames, any lookup which does not specify the
+    # username will be ambiguous
+    with pytest.raises(RuntimeError) as err:
+        selected = auth.select_matching_auth(two_vague_creds, "example.com")
+        assert f"{too_many} for hostname 'example.com' with no username specified" in err.value.args
+        assert "user1 which has no associated hostname" in err.value.args
+        assert "user2 which has no associated hostname" in err.value.args
+
+    # specifying a valid username should resolve the ambiguity
+    for username in ["user1", "user2"]:
+        selected = auth.select_matching_auth(two_vague_creds, "example.com", username)
+        assert selected.username == username
+
+    two_vague_creds = [
+        auth.Auth("user1", "pass1"),
+        auth.Auth("user3", "pass3", host="example.com"),
+    ]
+    # given a credential with no hostname and one with, a request which matches the one with a
+    # hostname should _not_ be ambiguous
+    selected = auth.select_matching_auth(two_vague_creds, "example.com")
+    assert selected.username == "user3"
+
+    two_specific_creds = [
+        auth.Auth("user3", "pass3", host="example.com"),
+        auth.Auth("user4", "pass4", host="example.com"),
+    ]
+
+    # given two credentials which both exactly match the requested hostname there should again be
+    # an ambiguity
+    with pytest.raises(RuntimeError) as err:
+        selected = auth.select_matching_auth(two_specific_creds, "example.com")
+        assert f"{too_many} for hostname 'example.com'" in err.value.args
+        assert "user3 for 'example.com'" in err.value.args
+        assert "user4 for 'example.com'" in err.value.args
+
+    # specifying a valid username should again resolve the ambiguity
+    for username in ["user3", "user4"]:
+        selected = auth.select_matching_auth(two_specific_creds, "example.com", username)
+        assert selected.username == username
+
+    # No single source of credentials should issue two credentials with the same username, however,
+    # two separate issuers could issue ones with the same name, and if neither specifies a hostname
+    # they will be ambiguous.
+    # (Duplicate usernames with matching hostnames should be impossible, as there should not be two
+    # issuers for the same hostname)
+    duplicate_users = [
+        auth.Auth("user", "pass5"),
+        auth.Auth("user", "pass6"),
+    ]
+    with pytest.raises(RuntimeError) as err:
+        selected = auth.select_matching_auth(duplicate_users, "example.com")
+        assert f"{too_many} for hostname 'example.com'" in err.value.args
+        assert "user which has no associated hostname" in err.value.args
+        assert "user which has no associated hostname" in err.value.args
+
+    # specifying a username woun't help, since they are duplicates
+    with pytest.raises(RuntimeError) as err:
+        selected = auth.select_matching_auth(duplicate_users, "example.com", "user")
+        assert f"{too_many} for hostname 'example.com'" in err.value.args
+        assert "user which has no associated hostname" in err.value.args
+        assert "user which has no associated hostname" in err.value.args
 
 
 def test_setup_auth(script_runner, tmpdir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, mock_open, MagicMock
 import sys
 import pytest
+import json
 from io import StringIO
 import io
 
@@ -136,7 +137,28 @@ def test_cli_subscribe(script_runner):
         assert ret.stderr == ""
 
         # verify broker url was processed
-        mock_stream.assert_called_with(broker_url, "r")
+        mock_stream.assert_called_with(broker_url, "r", group_id=None)
+
+        ret = script_runner.run("hop", "subscribe", broker_url, "--no-auth", "--group-id", "group")
+
+        # verify CLI output
+        assert ret.success
+        assert ret.stderr == ""
+
+        # verify consumer group ID was used
+        mock_stream.assert_called_with(broker_url, "r", group_id="group")
+
+    message_body = "some-message"
+    message_data = {"format": "blob", "content": message_body}
+    fake_message = MagicMock()
+    fake_message.value = MagicMock(return_value=json.dumps(message_data).encode("utf-8"))
+    mock_instance = MagicMock()
+    mock_instance.stream = MagicMock(return_value=[fake_message])
+    with patch("hop.io.consumer.Consumer", MagicMock(return_value=mock_instance)):
+        ret = script_runner.run("hop", "--debug", "subscribe", broker_url, "--no-auth")
+        assert ret.success
+        assert ret.stderr == ""
+        assert message_body in ret.stdout
 
 
 def dummy_topic_info(topic, error=None):
@@ -231,7 +253,7 @@ def test_cli_list_topics(script_runner, auth_config, tmpdir):
     # general listing with authentication
     with temp_config(tmpdir, auth_config) as config_dir, temp_environ(XDG_CONFIG_HOME=config_dir), \
             patch("confluent_kafka.Consumer", make_consumer_mock(topic_results)) as mock_consumer:
-        ret = script_runner.run("hop", "--debug", "list-topics", broker_url)
+        ret = script_runner.run("hop", "list-topics", broker_url)
 
         assert ret.success
         assert ret.stderr == ""
@@ -243,6 +265,11 @@ def test_cli_list_topics(script_runner, auth_config, tmpdir):
 
         mock_consumer.assert_called()
         mock_consumer.return_value.list_topics.assert_called_with()
+
+    # attempting to use multiple brokers should provoke an error
+    ret = script_runner.run("hop", "list-topics", "kafka://example.com,example.net")
+    assert not ret.success
+    assert "Multiple broker addresses are not supported" in ret.stderr
 
 
 def test_cli_auth(script_runner):

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -17,8 +17,9 @@ def check_config_file(config_path, username, password):
 
 def test_get_config_path(tmpdir):
     with temp_environ(HOME=str(tmpdir)):
-        # this change will revert at the end of the with block
-        del os.environ["XDG_CONFIG_HOME"]
+        if "XDG_CONFIG_HOME" in os.environ:
+            # this change will revert at the end of the with block
+            del os.environ["XDG_CONFIG_HOME"]
 
         # with HOME set but not XDG_CONFIG_HOME the config location should resolve to inside
         # ${HOME}/.config

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -34,6 +34,30 @@ def test_get_config_path(tmpdir):
             assert config_loc == expected_path
 
 
+def test_get_config_path_auth(tmpdir):
+    with temp_environ(HOME=str(tmpdir)):
+        if "XDG_CONFIG_HOME" in os.environ:
+            # this change will revert at the end of the with block
+            del os.environ["XDG_CONFIG_HOME"]
+
+        # with HOME set but not XDG_CONFIG_HOME the config location should resolve to inside
+        # ${HOME}/.config
+        expected_path = os.path.join(tmpdir, ".config", "hop", "auth.toml")
+        config_loc = configure.get_config_path("auth")
+        assert config_loc == expected_path
+
+        with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+            # with XDG_CONFIG_HOME set, no .config path component should be assumed
+            expected_path = os.path.join(tmpdir, "hop", "auth.toml")
+            config_loc = configure.get_config_path("auth")
+            assert config_loc == expected_path
+
+
+def test_get_config_path_invalid(tmpdir):
+    with pytest.raises(ValueError):
+        configure.get_config_path("hairstyle")
+
+
 def test_write_config_file(tmpdir):
     config_file = tmpdir + "/config"
     username = "scimma"


### PR DESCRIPTION
Two features are removed, due to incompatibility with this one:
- Consumer group IDs can no longer be specified as part of a broker URL, as the userinfo is used as a credential username.
- Multiple brokers cannot be specified in a single URL, as this creates ambiguity in selecting credentials by hostname.

Writing configuration files in the new format and providing a user interface for managing them will be implemented subsequently.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.
