### PR TITLE
Bug/auth data fidelity

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -48,18 +48,52 @@ class Auth(auth.SASLAuth):
 
     @property
     def username(self):
+        """The username for this credential"""
         return self._username
 
     @property
+    def password(self):
+        """The password for this credential"""
+        return self._config["sasl.password"]
+
+    @property
     def hostname(self):
+        """The hostname with which this creential is associated,
+            or the empty string if the credential did not contain this information
+        """
         return self._hostname
+
+    @property
+    def mechanism(self):
+        """The authentication mechanism to use"""
+        return self._config["sasl.mechanism"]
+
+    @property
+    def protocol(self):
+        """The communication protocol to use"""
+        return self._config["security.protocol"]
+
+    @property
+    def ssl(self):
+        """Whether communication should be secured with SSL"""
+        return self.protocol != "SASL_PLAINTEXT"
+
+    @property
+    def ssl_ca_location(self):
+        """The location of the Certfificate Authority data used for SSL,
+            or None if SSL is not enabled
+        """
+        if "ssl.ca.location" not in self._config:
+            return None
+        return self._config["ssl.ca.location"]
 
     def __eq__(self, other):
         return (self._username == other._username
-                and self._config["sasl.password"] == other._config["sasl.password"]
+                and self.password == other.password
                 and self.hostname == other.hostname
-                and self._config["security.protocol"] == other._config["security.protocol"]
-                and self._config["sasl.mechanism"] == other._config["sasl.mechanism"])
+                and self.mechanism == other.mechanism
+                and self.protocol == other.protocol
+                and self.ssl_ca_location == other.ssl_ca_location)
 
 
 def load_auth(config_file=None):
@@ -322,9 +356,10 @@ def write_auth_data(config_file, credentials):
     """
     cred_list = []
     for cred in credentials:
-        cred_dict = {"username": cred.username, "password": cred._config["sasl.password"]}
+        cred_dict = {"username": cred.username, "password": cred.password}
         if len(cred.hostname) > 0:
             cred_dict["hostname"] = cred.hostname
+
         cred_list.append(cred_dict)
 
     os.makedirs(os.path.dirname(config_file), exist_ok=True)


### PR DESCRIPTION
## Description

Write optional credential fields as appropriate.
Support reading optional fields from CSV.
Fixes #137.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
~* [ ] Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.