### PR TITLE
Stream: Change default to listen to messages indefinitely (until_eos=False)

### DIFF
--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -35,7 +35,8 @@ Consume messages
     hop subscribe kafka://hostname:port/gcn -s EARLIEST
 
 This will read messages from the gcn topic from the earliest offset
-and read messages until an end of stream (EOS) is received.
+and read messages as they arrive. By default this will listen to
+messages until the user stops the program (Ctrl+C to stop).
 
 View Available Topics
 ^^^^^^^^^^^^^^^^^^^^^
@@ -109,7 +110,7 @@ One can consume messages through the python API as follows:
              print(message)
 
 This will listen to the Hop broker, listening to new messages and printing them to
-stdout as they arrive until there are no more messages in the stream.
+stdout as they arrive.
 By default, this will only process new messages since the connection was opened.
 The :code:`start_at` option lets you control where in the stream you can start listening
 from. For example, if you'd like to listen to all messages stored in a topic, you can do:

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -19,13 +19,14 @@ Let's open up a stream and show the :code:`Stream` object in action:
 
     from hop import Stream
 
-    stream = Stream(persist=True)
+    stream = Stream(until_eos=True)
     with stream.open("kafka://hostname:port/topic", "r") as s:
         for message in s:
              print(message)
 
-The :code:`persist` option allows one to listen to messages forever
-and keeps the connection open after an end of stream (EOS) is received.
+The :code:`until_eos` option allows one to listen to messages until
+the no more messages are available (EOS or end of stream). By default
+the connection is kept open indefinitely.
 This is to allow long-lived connections where one may set up a service
 to process incoming GCNs, for example.
 
@@ -44,7 +45,7 @@ A complete list of configurable options in :code:`Stream` are:
 
 * :code:`auth`: A `bool` or :code:`auth.Auth` instance to provide authentication
 * :code:`start_at`: The message offset to start at, by passing in an :code:`io.StartPosition`
-* :code:`persist`: Whether to keep a long-live connection to the client beyond EOS
+* :code:`until_eos`: Whether to stop processing messages after an EOS is received
 
 One doesn't have to use the context manager protocol (:code:`with` block)
 to open up a stream as long as the stream is explicitly closed afterwards:

--- a/hop/io.py
+++ b/hop/io.py
@@ -36,15 +36,15 @@ class Stream(object):
             loading from :meth:`auth.load_auth <hop.auth.load_auth>` if set to
             True. To disable authentication, set to False.
         start_at: The message offset to start at in read mode. Defaults to LATEST.
-        persist: Whether to listen to new messages forever or stop
-            when EOS is received in read mode. Defaults to False.
+        until_eos: Whether to listen to new messages forever (False) or stop
+            when EOS is received in read mode (True). Defaults to False.
 
     """
 
-    def __init__(self, auth=True, start_at=StartPosition.LATEST, persist=False):
+    def __init__(self, auth=True, start_at=StartPosition.LATEST, until_eos=False):
         self._auth = [auth] if isinstance(auth, Auth) else auth
         self.start_at = start_at
-        self.persist = persist
+        self.until_eos = until_eos
 
     @property
     @lru_cache(maxsize=1)
@@ -119,7 +119,7 @@ class Stream(object):
                 topics,
                 start_at=self.start_at,
                 auth=credential,
-                read_forever=self.persist,
+                read_forever=not self.until_eos,
             )
         else:
             raise ValueError("mode must be either 'w' or 'r'")

--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -35,11 +35,11 @@ def _add_parser_args(parser):
         help="Set the message offset offset to start at. Default: LATEST.",
     )
     parser.add_argument(
-        "-p",
-        "--persist",
+        "-e",
+        "--until-eos",
         action="store_true",
-        help="If set, persist or listen to messages indefinitely. "
-             "Otherwise, will stop listening when EOS is received.",
+        help="If set, only subscribe until EOS is received (end of stream). "
+             "Otherwise, listen to messages indefinitely.",
     )
     parser.add_argument(
         "-g", "--group-id",
@@ -56,7 +56,7 @@ def _main(args):
 
     """
     start_at = io.StartPosition[args.start_at]
-    stream = io.Stream(auth=(not args.no_auth), start_at=start_at, persist=args.persist)
+    stream = io.Stream(auth=(not args.no_auth), start_at=start_at, until_eos=args.until_eos)
 
     with stream.open(args.url, "r", group_id=args.group_id) as s:
         for message in s:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,7 +108,7 @@ def test_cli_publish_blob_types(mock_broker, mock_producer, mock_consumer):
             assert mock_broker.has_message("topic", expected_msg)
 
             # reading from the broker should yield messages which match the originals
-            with io.Stream(persist=False, start_at=None, auth=False).open(read_url, "r") as s:
+            with io.Stream(start_at=None, auth=False).open(read_url, "r") as s:
                 extracted_msgs = []
                 for extracted_msg in s:
                     extracted_msgs.append(extracted_msg)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -86,7 +86,7 @@ def test_stream_read(circular_msg):
     fake_message.value = MagicMock(return_value=json.dumps(message_data).encode("utf-8"))
     mock_instance = MagicMock()
     mock_instance.stream = MagicMock(return_value=[fake_message])
-    stream = io.Stream(persist=False, start_at=start_at, auth=False)
+    stream = io.Stream(start_at=start_at, until_eos=True, auth=False)
     with patch("hop.io.consumer.Consumer", MagicMock(return_value=mock_instance)):
         broker_url1 = f"kafka://hostname:port/{topic}"
         broker_url2 = f"kafka://{group_id}@hostname:port/{topic}"
@@ -119,7 +119,7 @@ def test_stream_read_multiple(circular_msg):
     topic2_message.topic = MagicMock(return_value=topic2)
     mock_instance = MagicMock()
     mock_instance.stream = MagicMock(return_value=[topic1_message, topic2_message])
-    stream = io.Stream(persist=False, start_at=start_at, auth=False)
+    stream = io.Stream(start_at=start_at, until_eos=True, auth=False)
     with patch("hop.io.consumer.Consumer", MagicMock(return_value=mock_instance)):
         broker_url = f"kafka://{group_id}@hostname:port/{topic1},{topic2}"
 
@@ -141,9 +141,9 @@ def test_stream_write(circular_msg, circular_text, mock_broker, mock_producer):
         broker_url = f"kafka://localhost:port/{topic}"
         auth = Auth("user", "password")
         start_at = io.StartPosition.EARLIEST
-        persist = False
+        until_eos = True
 
-        stream = io.Stream(start_at=start_at, persist=persist, auth=auth)
+        stream = io.Stream(start_at=start_at, until_eos=until_eos, auth=auth)
 
         # verify only 1 topic is allowed in write mode
         with pytest.raises(ValueError):
@@ -248,7 +248,7 @@ def test_mark_done(circular_msg):
     mock_message.value = MagicMock(return_value=json.dumps(message_data).encode("utf-8"))
     mock_instance = MagicMock()
     mock_instance.stream = MagicMock(return_value=[mock_message])
-    stream = io.Stream(persist=False, start_at=start_at, auth=False)
+    stream = io.Stream(until_eos=True, start_at=start_at, auth=False)
 
     with patch("hop.io.consumer.Consumer", MagicMock(return_value=mock_instance)):
         with stream.open("kafka://hostname:port/gcn", "r") as s:


### PR DESCRIPTION
## Description

This changes the default behavior within the client so that listening to messages indefinitely is the default. See #145. The flag used to control this behavior was changed from `persist/--persist` to `until_eos/--until-eos`. Setting `until_eos=True/--until-eos` will only read messages until an end of stream (EOS) is received.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
