### PR TITLE
Support new publication features offered by adc.

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -70,7 +70,7 @@ class Stream(object):
         else:
             return self._auth
 
-    def open(self, url, mode="r", group_id=None):
+    def open(self, url, mode="r", group_id=None, **kwargs):
         """Opens a connection to an event stream.
 
         Args:
@@ -107,7 +107,7 @@ class Stream(object):
                 raise ValueError("must specify exactly one topic in write mode")
             if group_id is not None:
                 warnings.warn("group ID has no effect when opening a stream in write mode")
-            return Producer(broker_addresses, topics[0], auth=credential)
+            return Producer(broker_addresses, topics[0], auth=credential, **kwargs)
         elif mode == "r":
             if group_id is None:
                 username = credential.username if credential is not None else None
@@ -120,6 +120,7 @@ class Stream(object):
                 start_at=self.start_at,
                 auth=credential,
                 read_forever=not self.until_eos,
+                **kwargs,
             )
         else:
             raise ValueError("mode must be either 'w' or 'r'")
@@ -360,8 +361,6 @@ class Producer:
             topic: The name of the topic to which to write.
             auth: An adc.auth.SASLAuth object specifying client authentication
                 to use.
-            delivery_callback: A callback which will be called when each message
-                is either delivered or permenantly fails to be delivered.
             error_callback: A callback which will be called with any
                 confluent_kafka.KafkaError objects produced representing internal
                 Kafka errors.
@@ -374,18 +373,22 @@ class Producer:
         self._producer = producer.Producer(producer.ProducerConfig(
             broker_urls=broker_addresses,
             topic=topic,
-            delivery_callback=errors.raise_delivery_errors,
             **kwargs,
         ))
 
-    def write(self, message):
+    def write(self, message, headers=None, delivery_callback=errors.raise_delivery_errors):
         """Write messages to a stream.
 
         Args:
             message: The message to write.
+            headers: Any headers to attach to the message, either as a dictionary
+                mapping strings to strings, or as a list of 2-tuples of strings.
+            delivery_callback: A callback which will be called when each message
+                is either delivered or permenantly fails to be delivered.
 
         """
-        self._producer.write(self._pack(message))
+        self._producer.write(self._pack(message), headers=headers,
+                             delivery_callback=delivery_callback)
 
     @staticmethod
     def _pack(message):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -136,6 +136,7 @@ def test_stream_write(circular_msg, circular_text, mock_broker, mock_producer):
     topic = "gcn"
     mock_adc_producer = mock_producer(mock_broker, topic)
     expected_msg = json.dumps(Blob(circular_msg).serialize()).encode("utf-8")
+    headers = {"some header": "some value"}
     with patch("hop.io.producer.Producer", autospec=True, return_value=mock_adc_producer):
 
         broker_url = f"kafka://localhost:port/{topic}"
@@ -155,15 +156,15 @@ def test_stream_write(circular_msg, circular_text, mock_broker, mock_producer):
 
         mock_broker.reset()
         with stream.open(broker_url, "w") as s:
-            s.write(circular_msg)
-            assert mock_broker.has_message(topic, expected_msg)
+            s.write(circular_msg, headers)
+            assert mock_broker.has_message(topic, expected_msg, headers)
 
         # repeat, but with a manual close instead of context management
         mock_broker.reset()
         s = stream.open(broker_url, "w")
-        s.write(circular_msg)
+        s.write(circular_msg, headers)
         s.close()
-        assert mock_broker.has_message(topic, expected_msg)
+        assert mock_broker.has_message(topic, expected_msg, headers)
 
 
 def test_stream_auth(auth_config, tmpdir):


### PR DESCRIPTION
## Description

This includes message headers, and changes the delivery callback to be on a per-message basis, rather than per stream.

This depends on https://github.com/astronomy-commons/adc-streaming/commit/a3daccaa86ff072aad75402c39e094b24be690bf which is not yet in a release. 

## Checklist

* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [ ] `make test` runs without errors.
* [ ] `make lint` doesn't give any warnings.
* [ ] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.