### PR TITLE
Add the missing force option to `hop auth add`

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -530,6 +530,9 @@ def _add_parser_args(parser):
                                            "specified either via a CSV file or interactively")
     add_cred_parser.add_argument("cred_file", type=str, default=None, nargs='?',
                                  help="Import credentials from CSV file")
+    add_cred_parser.add_argument("--force", action="store_true", default=False,
+                                 help="If set, overwrite any existing credential when a new one "
+                                 "with the same username and hostname is added")
 
     del_cred_parser = subparser.add_parser("remove", help="Delete a stored credential")
     del_cred_parser.add_argument("name", type=str,


### PR DESCRIPTION
## Description

Fixes https://github.com/scimma/hop-client/issues/153

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.