### PR TITLE
UX: Improve logging in CLI when publishing/subscribing

### DIFF
--- a/hop/__main__.py
+++ b/hop/__main__.py
@@ -1,5 +1,5 @@
 import argparse
-import signal
+import logging
 import sys
 import traceback
 
@@ -11,6 +11,9 @@ from . import subscribe
 from . import version
 from . import list_topics
 from .utils import cli as cli_utils
+
+
+logger = logging.getLogger("hop")
 
 
 def set_up_cli():
@@ -81,9 +84,8 @@ To load your credential, run `hop auth add`
 
 
 def main():
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
     parser = set_up_cli()
+
     try:
         args = parser.parse_args()
     except SystemExit:
@@ -91,6 +93,8 @@ def main():
         raise
     try:
         args.func(args)
+    except KeyboardInterrupt:
+        logger.info("received keyboard interrupt, closing")
     except Exception as ex:
         if args.debug:
             traceback.print_exc(file=sys.stderr)

--- a/hop/auth.py
+++ b/hop/auth.py
@@ -1,13 +1,17 @@
-from adc import auth
-from . import configure
-import os
-import getpass
-import logging
+from collections.abc import Mapping
 import csv
 import errno
+import getpass
+import logging
+import os
 import stat
 import toml
-from collections.abc import Mapping
+
+from adc import auth
+
+from . import configure
+from . import cli
+
 
 SASLMethod = auth.SASLMethod
 
@@ -519,6 +523,8 @@ def delete_credential(name: str):
 
 
 def _add_parser_args(parser):
+    cli.add_logging_opts(parser)
+
     subparser = parser.add_subparsers(title="commands", metavar="<command>", dest="command")
     subparser.required = True
 
@@ -542,9 +548,7 @@ def _main(args):
     """Authentication configuration utilities.
 
     """
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s | %(name)s : %(levelname)s : %(message)s",
-    )
+    cli.set_up_logger(args)
 
     if args.command == "locate":
         print(configure.get_config_path("auth"))

--- a/hop/cli.py
+++ b/hop/cli.py
@@ -32,10 +32,10 @@ def add_logging_opts(parser):
     """
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
-        "--quiet", action="store_true", help="If set, only display warnings and errors."
+        "-q", "--quiet", action="store_true", help="If set, only display warnings and errors."
     )
     group.add_argument(
-        "--verbose", action="store_true", help="If set, display additional logging messages."
+        "-v", "--verbose", action="store_true", help="If set, display additional logging messages."
     )
 
 

--- a/hop/cli.py
+++ b/hop/cli.py
@@ -1,3 +1,10 @@
+import logging
+import sys
+
+
+logger = logging.getLogger("hop")
+
+
 def add_client_opts(parser):
     """Add general client options to an argument parser.
 
@@ -14,3 +21,53 @@ def add_client_opts(parser):
     parser.add_argument(
         "--no-auth", action="store_true", help="If set, disable authentication."
     )
+
+
+def add_logging_opts(parser):
+    """Add logging client options to an argument parser.
+
+    Args:
+        parser: An ArgumentParser instance to add client options to.
+
+    """
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--quiet", action="store_true", help="If set, only display warnings and errors."
+    )
+    group.add_argument(
+        "--verbose", action="store_true", help="If set, display additional logging messages."
+    )
+
+
+def get_log_level(args):
+    """Determine the log level from logging options.
+
+    Args:
+        args: The parsed argparse arguments.
+
+    Returns:
+        the logging log level.
+
+    """
+    if args.quiet:
+        return logging.WARNING
+    elif args.verbose:
+        return logging.DEBUG
+    else:
+        return logging.INFO
+
+
+def set_up_logger(args):
+    """Set up common logging settings for CLI usage.
+
+    Args:
+        args: The parsed argparse arguments.
+
+    """
+    log_level = get_log_level(args)
+    logger.setLevel(log_level)
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(log_level)
+    formatter = logging.Formatter("%(asctime)s | hop : %(levelname)s : %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -1,6 +1,9 @@
 import logging
 import os
 
+from . import cli
+
+
 logger = logging.getLogger("hop")
 
 
@@ -35,6 +38,8 @@ def get_config_path(type: str = "general"):
 
 
 def _add_parser_args(parser):
+    cli.add_logging_opts(parser)
+
     subparser = parser.add_subparsers(title="commands", metavar="<command>", dest="command")
     subparser.required = True
 
@@ -49,9 +54,7 @@ def _main(args):
     """Configuration utilities.
 
     """
-    logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s | %(name)s : %(levelname)s : %(message)s",
-    )
+    cli.set_up_logger(args)
 
     if args.command == "locate":
         print(get_config_path(args.type))

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,12 +1,18 @@
-import sys
 import json
+import logging
+import sys
 
 from . import cli
 from . import io
 
 
+logger = logging.getLogger("hop")
+
+
 def _add_parser_args(parser):
     cli.add_client_opts(parser)
+    cli.add_logging_opts(parser)
+
     parser.add_argument(
         "message", metavar="MESSAGE", nargs="*", help="Messages to publish.",
     )
@@ -23,10 +29,13 @@ def _main(args):
     """Publish messages.
 
     """
+    cli.set_up_logger(args)
+
     loader = io.Deserializer[args.format]
     stream = io.Stream(auth=(not args.no_auth))
 
     with stream.open(args.url, "w") as s:
+        logger.info("publishing messages to stream")
         for message_file in args.message:
             message = loader.load_file(message_file)
             s.write(message)

--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -1,8 +1,13 @@
 import json
+import logging
+import sys
 
 from . import cli
 from . import io
 from . import models
+
+
+logger = logging.getLogger("hop")
 
 
 def print_message(message, json_dump=False):
@@ -20,11 +25,12 @@ def print_message(message, json_dump=False):
             message = json.dumps(message.asdict())
         else:
             message = json.dumps(message)
-    print(message)
+    print(message, file=sys.stdout, flush=True)
 
 
 def _add_parser_args(parser):
     cli.add_client_opts(parser)
+    cli.add_logging_opts(parser)
 
     # consumer options
     parser.add_argument(
@@ -55,6 +61,8 @@ def _main(args):
     """Subscribe to messages.
 
     """
+    cli.set_up_logger(args)
+
     start_at = io.StartPosition[args.start_at]
     stream = io.Stream(auth=(not args.no_auth), start_at=start_at, until_eos=args.until_eos)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,7 +58,8 @@ def test_cli_publish(script_runner, message_format, message_parameters_dict):
 
         broker_url = "kafka://hostname:port/message"
         ret = script_runner.run(
-            "hop", "publish", broker_url, test_file, "-f", message_format.upper(), "--no-auth",
+            "hop", "publish", broker_url, test_file, "--quiet",
+            "-f", message_format.upper(), "--no-auth",
         )
 
         # verify CLI output
@@ -169,7 +170,7 @@ def test_cli_subscribe(script_runner):
     mock_instance = MagicMock()
     mock_instance.stream = MagicMock(return_value=[fake_message])
     with patch("hop.io.consumer.Consumer", MagicMock(return_value=mock_instance)):
-        ret = script_runner.run("hop", "--debug", "subscribe", broker_url, "--no-auth")
+        ret = script_runner.run("hop", "--debug", "subscribe", broker_url, "--no-auth", "--quiet")
         assert ret.success
         assert ret.stderr == ""
         assert message_body in ret.stdout

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -50,7 +50,6 @@ def test_get_config_path_invalid(tmpdir):
 
 def test_no_command_configure(script_runner):
     warning_message = (
-        "usage: hop configure [-h] <command> ...\n"
         "hop configure: error: the following arguments are required: <command>"
     )
     ret = script_runner.run("hop", "configure")


### PR DESCRIPTION
## Description

Implements #146. Added some logging functionality in the cli module and shared throughout our CLI commands. By default, INFO-level logs are displayed and routed to stderr to allow piping/redirects to continue working. This can be changed with `--quiet` which only shows warnings/errors or `--verbose` which also shows DEBUG-level logs as well.

A couple of other changes unrelated to this but was caught when adding in logging include:
* Organize imports in `auth` module. I had to add an import and saw it wasn't organized like some of the other modules.
* Remove default signal handler in `__main__.py`. This was causing issues with KeyboardInterrupts and prematurely exiting the program without closing the producer/consumer instances. Instead, this case is handled explicitly now.
* In a similar spirit to the previous point, I noticed that the producer didn't call `close()` when using the context manager, so that's now being done as well.
* Some tests were modified to run with `--quiet` to test stderr/stdout in a similar manner as before. Also the test_configure test was modified to not bake in the 'usage' so changes to the command line arguments don't need a change in the test.

Example logs:

```
$ hop subscribe --no-auth kafka://localhost:9092/test -s EARLIEST -e
2021-09-29 15:59:52,785 | hop : INFO : group ID not specified, generating a random group ID: 5VSQC2J1KR
2021-09-29 15:59:52,785 | hop : INFO : connecting to kafka://localhost:9092
2021-09-29 15:59:52,785 | hop : INFO : subscribing to topics: ['test']
2021-09-29 15:59:52,788 | hop : INFO : processing messages from stream
one
two
three
four
2021-09-29 15:59:53,789 | hop : INFO : finished processing messages
2021-09-29 15:59:53,789 | hop : INFO : closing connection
```

```
$ cat test.txt | hop publish --no-auth kafka://localhost:9092/test
2021-09-29 16:00:15,652 | hop : INFO : connecting to kafka://localhost:9092
2021-09-29 16:00:15,653 | hop : INFO : publishing to topic: test
2021-09-29 16:00:15,653 | hop : INFO : publishing messages to stream
```

Closes #146.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
