### PR TITLE
Pin adc-streaming to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 1.0.2",
+    "adc-streaming >= 1.0.2, < 2.0",
     "dataclasses ; python_version < '3.7'",
     "pluggy >= 0.11",
     "toml >= 0.9.4",


### PR DESCRIPTION
## Description

This should avoid issues with the upcoming major release of adc-streaming once it's available in PyPI with the current released version of hop-client. The working plan I had in mind for releases are:

* 0.4.1 release of hop-client with this pinning in place.
* 2.0 release of adc-streaming.
* 0.5.0 release of hop-client with newest changes (and #155) pinned with adc-streaming >= 2.0.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
