### PR TITLE
Remove outdated requirements files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,20 @@ A Makefile is provided to ease in testing, deployment and generating documentati
 
 A list of commands can be listed with `make help`.
 
-In addition, two extras are provided when installing the scimma client that installs
+In addition, two extras are provided when installing the hop client that installs
 the required test and documentation libraries:
 
+* dev: dependencies required for testing, linting and packaging
+* docs: dependencies required for building documentation
+
+Assuming you've cloned the repository and are in the project's root directory, you can
+install hop-client alongside all the required development dependencies by running:
+
 ```
-pip install -U hop-client[dev,docs]
+pip install .[dev,docs]
 ```
+
+### Releases
 
 To mark a new version, use Github tags to mark your commit with a [semver](https://semver.org/) version:
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,0 @@
-pytest==5.3.5
-Sphinx==2.4.1
-pytest-cov==2.8.1
-pytest-console-scripts==0.2.0 
-flake8-black==0.1.1 
-sphinx_rtd_theme==0.4.3
-sphinxcontrib-programoutput==0.15
-flake8==3.7.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-adc-streaming>=1.0.2
-toml>=0.9.4
-xmltodict>=0.9.0


### PR DESCRIPTION
## Description

These files aren't used and are outdated. The authoritative set of dependencies/versions is baked into `setup.py` and having these around are confusing at best.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
