### PR TITLE
Implementation of robust publication

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -10,6 +10,7 @@ hop-client API
     cli
     configure
     io
+    robust_publisher
     publish
     subscribe
     models

--- a/doc/api/robust_publisher.rst
+++ b/doc/api/robust_publisher.rst
@@ -1,0 +1,16 @@
+.. _robust_publisher:
+
+hop.robust_publisher
+####################
+
+.. module:: hop.robust_publisher
+
+.. autoclass:: PublicationJournal     
+   :members: 
+
+   .. automethod:: __init__
+
+.. autoclass:: RobustProducer     
+   :members: 
+
+   .. automethod:: __init__

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ User's Guide
    user/stream
    user/auth
    user/models
+   user/robust_publication
    user/commands
 
 API Reference

--- a/doc/user/robust_publication.rst
+++ b/doc/user/robust_publication.rst
@@ -11,18 +11,18 @@ The RobustProducer
 In some situations, it may be critical to ensure that messages are sent to the Kafka broker, even when the
 intervening network may be unreliable, the sending process may be killed unexpectedly, and so on.
 The :class:`RobustProducer <hop.robust_publisher.RobustProducer>` object extends the capabilities of the 
-simple :class:`Producer <hop.io.Producer>` to cover this need better. 
+simple :class:`Producer <hop.io.Producer>` to provide this functionality. 
 
 The two main mechanisms used by the :class:`RobustProducer <hop.robust_publisher.RobustProducer>` are to 
 maintain a local journal of messages which are queued to be sent or are in flight, and to listen for
 confirmation messages from the Kafka broker that messages have been received.
-The use of receipt confirmations enables resending messages which are lost in the network or if the broker
+The use of receipt confirmations enables the resending of messages which are lost in the network or if the broker
 fails unexpectedly, while use of the journal ensures that even if the sending program is stopped suddenly, 
 it can resend any messages whose receipt was not yet confirmed. 
 Implications of this are that local disk space is required for the message journal (and the amount of
 space used will be at least that of the sum of sizes of all messages in flight at the same time), and that
-at-least-once delivery is guarnteed, but that in providing that guarantee, messages may be duplicated.
-For example, duplication on the broker will occur if the producer sends the mesage, but the broker's
+at-least-once delivery is guaranteed, but that in providing that guarantee, messages may be duplicated.
+For example, duplication of messages on the broker will occur if the producer sends the mesage, but the broker's
 confirmation is lost in the network, so the producer is forced to assume that the message did not go
 through and resends it. 
 Clients should be prepared to handle duplicate messages appropriately. 

--- a/doc/user/robust_publication.rst
+++ b/doc/user/robust_publication.rst
@@ -1,0 +1,107 @@
+==================
+Robust Publication
+==================
+
+.. contents::
+   :local:
+
+The RobustProducer
+------------------
+
+In some situations, it may be critical to ensure that messages are sent to the Kafka broker, even when the
+intervening network may be unreliable, the sending process may be killed unexpectedly, and so on.
+The :class:`RobustProducer <hop.robust_publisher.RobustProducer>` object extends the capabilities of the 
+simple :class:`Producer <hop.io.Producer>` to cover this need better. 
+
+The two main mechanisms used by the :class:`RobustProducer <hop.robust_publisher.RobustProducer>` are to 
+maintain a local journal of messages which are queued to be sent or are in flight, and to listen for
+confirmation messages from the Kafka broker that messages have been received.
+The use of receipt confirmations enables resending messages which are lost in the network or if the broker
+fails unexpectedly, while use of the journal ensures that even if the sending program is stopped suddenly, 
+it can resend any messages whose receipt was not yet confirmed. 
+Implications of this are that local disk space is required for the message journal (and the amount of
+space used will be at least that of the sum of sizes of all messages in flight at the same time), and that
+at-least-once delivery is guarnteed, but that in providing that guarantee, messages may be duplicated.
+For example, duplication on the broker will occur if the producer sends the mesage, but the broker's
+confirmation is lost in the network, so the producer is forced to assume that the message did not go
+through and resends it. 
+Clients should be prepared to handle duplicate messages appropriately. 
+
+Usage
+-----
+
+The simplest way to use the :class:`RobustProducer <hop.robust_publisher.RobustProducer>` is as a context
+manager:
+
+.. code:: python
+
+    from hop.robust_publisher import RobustProducer
+
+    with RobustProducer("kafka://hostname:port/topic") as publisher:
+        for message in messages:
+            publisher.write(message)
+
+To control the location where the message journal is stored, one may set the :code:`journal_path` option
+when constructing the :class:`RobustProducer <hop.robust_publisher.RobustProducer>`; the default is
+:code:`"publisher.journal"` which will place it the script's current working directory. 
+
+Message sending is asynchronous, so
+:meth:`RobustProducer.write <hop.robust_publisher.RobustProducer.write>` will return almost immediately,
+as it only queues the message for sending. 
+The :class:`RobustProducer <hop.robust_publisher.RobustProducer>` blocks internally until all messages are
+successfully sent, so there can be a noticeable delay after all messages have been queued while they
+complete sending. 
+In the event of a network or broker failure, this delay may extend indefinitely. 
+
+The :meth:`RobustProducer constructor <hop.robust_publisher.RobustProducer.__init__>` also
+accepts an :code:`auth` argument for specifying the
+credentials with which it should connect, and will pass through any extra keyword arguments to
+:meth:`io.Stream.open <hop.io.Stream.open>`. 
+
+For more advanced uses, :class:`RobustProducer <hop.robust_publisher.RobustProducer>` can also be used
+directly without being treated as a context manager:
+
+.. code:: python
+
+    from hop.robust_publisher import RobustProducer
+
+    publisher = RobustProducer("kafka://hostname:port/topic")
+    publisher.start()
+
+    #. . .
+    publisher.write(some_message)
+    
+    #. . .
+    publisher.stop()
+
+When used in this way, it is necessary to call
+:meth:`RobustProducer.start <hop.robust_publisher.RobustProducer.start>`
+before sending any messages, and :meth:`RobustProducer.stop <hop.robust_publisher.RobustProducer.stop>`
+after all messages have been sent to shut down the
+:class:`RobustProducer <hop.robust_publisher.RobustProducer>`'s internal background worker thread.
+It is important to note that the user should *not* call
+:meth:`RobustProducer.run <hop.robust_publisher.RobustProducer.run>`, as this method is exposed only as a
+part of the python :class:`threading.Thread` interface, and will block whatever thread calls it,
+indefinitely. 
+Once stopped, a :class:`RobustProducer <hop.robust_publisher.RobustProducer>` object cannot be restarted. 
+
+Miscellaneous Details
+---------------------
+
+The message journal is intended to protect against disruption of the sending program, but at this time
+does not include meaningful protection against sudden failure of the machine on which the program is
+running; in particular, it does not ensure that data written to it is definitely flushed through
+filesystem or hardware caching layers. 
+As a result, issues like power failures can lead to data loss. 
+The journal does contain checksumming and other sanity checking which enable detecting most forms of data
+corruption, although truncation of the journal exactly at a boundary between entries currently cannot be
+detected.
+Currently, corruption of the journal will trigger an error and block (re)starting the
+:class:`RobustProducer <hop.robust_publisher.RobustProducer>`.
+
+Messages are written to the journal essentially in plain text, so users whose data is sensitive should
+take into account that the journal file must be suitably protected. 
+
+Currently, :meth:`RobustProducer.write <hop.robust_publisher.RobustProducer.write>` takes over the
+:code:`delivery_callback` option for :meth:`Producer.write <hop.io.Producer.write>` for its own use, so
+end users are not able to register their own delivery callback handlers. 

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -225,7 +225,7 @@ class PublicationJournal:
         return len(self.messages_to_send) > 0
 
     def get_next_message_to_send(self):
-        """Fetch the next mesage which should be sent
+        """Fetch the next message which should be sent
 
         Returns:
             The next message in the form of a tuple of (seqeunce number, message, message headers),
@@ -549,7 +549,7 @@ class RobustProducer(threading.Thread):
                        increase this value so that the publisher will wait to discover that each
                        message has been sent (in the success case) instead of sleeping and waiting
                        for another message to send. If this value is 'too low' (much smaller than
-                       both the time for a mesage to be sent and acknowledged and the time for the
+                       both the time for a message to be sent and acknowledged and the time for the
                        next message to be ready for sending), the publisher will waste CPU time
                        entering and exiting the internal function used to receive event
                        notifications. If this value is too large (larger than or similar in size to

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -484,12 +484,13 @@ class PublicationJournal:
                 self.requeue_message(seq_num)
 
     def get_delivery_callback(self, seq_num, lock=NullLock()):
-        """Construct a callback handler specific to a particular message which will either mark it
-            successfully sent or requeue it to send again.
+        """
+        Construct a callback handler specific to a particular message which will either mark it
+        successfully sent or requeue it to send again.
 
-            The callback which is produced will take two arguments: A confluent_kafka.KafkaError
-            describing any error in sending the message, and confluent_kafka.Message containing the
-            message itself.
+        The callback which is produced will take two arguments: A confluent_kafka.KafkaError
+        describing any error in sending the message, and confluent_kafka.Message containing the
+        message itself.
 
         Args:
             seq_num: The sequence number of the message in question, previously returned by

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -283,6 +283,128 @@ class PublicationJournal:
         del self.maybe_sent_messages[sequence_number]
         self.messages_to_send[sequence_number] = message
 
+    class _ReadPosition:
+        """A type for tracking logical read positions in a journal file."""
+
+        def __init__(self):
+            self.record_index = 0
+            self.record_start = 0
+
+    @staticmethod
+    def _read_raw_from_journal(journal, pos_info, size, name, allow_eof=False):
+        """Read a specified size of raw data from a strream, producing an error if it cannot be fully
+            read and end of file is not indicated to be tolerable.
+
+        Args:
+            journal: the stream from which to read
+            pos_info: logical position information used for error messages
+            size: the amount of data to read
+            name: description of the data to be read, for error messages
+            allow_eof: whether end of file is tolerable
+
+        Returns:
+            The block of data which was read
+
+        Raises:
+            RuntimeError: If the specified amount of data was not successfully read.
+        """
+        try:
+            buffer = journal.read(size)
+        except Exception:
+            raise RuntimeError(f"Journal corrupted: Unable to read {name}")
+        if len(buffer) == 0 and allow_eof:  # end of file
+            return buffer, True
+        elif len(buffer) < size:
+            raise RuntimeError("Journal corrupted: Unexpected end of file (unable to read "
+                               f"{name}) during record {pos_info.record_index} which began at file "
+                               f"offset {pos_info.record_start}")
+        if allow_eof:
+            return buffer, False
+        return buffer
+
+    @staticmethod
+    def _decode_raw_data(data, decoder, crc, name):
+        """Decode a block of raw data and update a running CRC.
+
+        Args:
+            data: the raw data to decode
+            decoder: the specific decoding function to apply
+            crc: the old value of the running CRC
+            name: a description of the data for error messages
+
+        Returns:
+            A tuple of the result of applying the decoder and the updated CRC
+
+        Raises:
+            RuntimeError: If the decoder produces an error
+        """
+        crc = zlib.crc32(data, crc) & 0xFFFFFFFF
+        try:
+            decoded = decoder(data)
+            return decoded, crc
+        except BaseException as e:
+            raise RuntimeError(f"Failed to decode {name}: {e}")
+
+    @staticmethod
+    def _read_recorded_header(journal, pos_info, bcrc, required_body_len, rec_len):
+        """Extract a recorrded message header from a stream.
+
+        Args:
+            journal: the stream from which to read
+            pos_info: logical position information used for error messages
+            bcrc: the CRC of the message body as read so far
+            required_body_len: the length the message record body must be to accomodate all
+                               claimed data
+            rec_len: the length of the message record body claimed in the record header
+
+        Returns:
+            A tuple consisting of the header key, header value, updated record body CRC, and
+            updated required record body length.
+
+        Raises:
+            RuntimeError: If any read operation fails, data item cannot be decoded, or the supposed
+                          header data does not fit inside the claimed record body length.
+        """
+        decode_int = PublicationJournal.decode_int
+        int_size = PublicationJournal.int_size
+        read = PublicationJournal._read_raw_from_journal
+        decode = PublicationJournal._decode_raw_data
+
+        raw_key_len = read(journal, pos_info, int_size, "message header key length")
+        key_len, bcrc = decode(raw_key_len, decode_int, bcrc,
+                               "message header key length")
+        if key_len > (rec_len - required_body_len):
+            raise RuntimeError(f"Journal corrupted: Claimed message header key length "
+                               f"({key_len}) exceeds remaining space in record body for"
+                               f" record {pos_info.record_index} which began at file offset "
+                               f"{pos_info.record_start}")
+        required_body_len += key_len
+
+        key = read(journal, pos_info, key_len, "message header key data")
+        bcrc = zlib.crc32(key, bcrc) & 0xFFFFFFFF
+
+        raw_val_len = read(journal, pos_info, int_size, "message header value length")
+        val_len, bcrc = decode(raw_val_len, decode_int, bcrc,
+                               "message header value length")
+        if val_len > (rec_len - required_body_len):
+            raise RuntimeError(f"Journal corrupted: Claimed message header value length"
+                               f" ({val_len}) exceeds remaining space in record body "
+                               f"for record {pos_info.record_index} which began at file offset "
+                               f"{pos_info.record_start}")
+        required_body_len += val_len
+
+        val = read(journal, pos_info, val_len, "message header value data")
+        bcrc = zlib.crc32(val, bcrc) & 0xFFFFFFFF
+
+        # confluent kafka requires keys in the form of unicode strings
+        try:
+            key = key.decode("utf-8")
+        except UnicodeError:
+            raise RuntimeError(f"Journal corrupted: Message header key is not valid "
+                               f"UTF-8 in record {pos_info.record_index} which began at file "
+                               f"offset {pos_info.record_start}")
+        return (key, val, bcrc, required_body_len)
+
     def _read_previous_journal(self):
         """Reload journal data from a previous session from disk.
 
@@ -293,55 +415,39 @@ class PublicationJournal:
         if not os.path.exists(self.journal_path):
             return  # nothing to do!
         journal = open(self.journal_path, "rb")
-        record_index = 0
-        record_start = 0
+        rpos = PublicationJournal._ReadPosition()
+        read = PublicationJournal._read_raw_from_journal
+        decode = PublicationJournal._decode_raw_data
+        read_header = PublicationJournal._read_recorded_header
         while True:
             decode_int = PublicationJournal.decode_int
             decode_crc = PublicationJournal.decode_crc
 
-            def read(size, name, allow_eof=False):
-                try:
-                    buffer = journal.read(size)
-                except Exception:
-                    raise RuntimeError(f"Journal corrupted: Unable to read {name}")
-                if len(buffer) == 0 and allow_eof:  # end of file
-                    return buffer, True
-                elif len(buffer) < size:
-                    raise RuntimeError("Journal corrupted: Unexpected end of file (unable to read "
-                                       f"{name}) during record {record_index} which began at file "
-                                       f"offset {record_start}")
-                if allow_eof:
-                    return buffer, False
-                return buffer
-
-            def decode(data, decoder, crc, name):
-                crc = zlib.crc32(data, crc) & 0xFFFFFFFF
-                return decoder(data), crc
-
-            record_start = journal.tell()
+            rpos.record_start = journal.tell()
 
             # Read the record header:
             hcrc = 0  # header CRC
             record_type_offset = journal.tell()
-            raw_rec_type, eof = read(self.int_size, "record type", allow_eof=True)
+            raw_rec_type, eof = read(journal, rpos, self.int_size, "record type", allow_eof=True)
             if eof:
                 break
             rec_type, hcrc = decode(raw_rec_type, decode_int, hcrc, "record type")
 
-            raw_rec_len = read(self.int_size, "record body length")
+            raw_rec_len = read(journal, rpos, self.int_size, "record body length")
             rec_len, hcrc = decode(raw_rec_len, decode_int, hcrc, "record body length")
 
-            raw_orig_body_crc = read(self.crc_size, "record body CRC")
+            raw_orig_body_crc = read(journal, rpos, self.crc_size, "record body CRC")
             orig_body_crc, hcrc = decode(raw_orig_body_crc, decode_crc, hcrc, "record body CRC")
 
-            raw_orig_hdr_crc = read(self.crc_size, "record header CRC")
+            raw_orig_hdr_crc = read(journal, rpos, self.crc_size, "record header CRC")
             # don't update recalculated CRC with raw_orig_hdr_crc, since it did not include itself
             orig_hdr_crc, _ = decode(raw_orig_hdr_crc, decode_crc, 0, "record header CRC")
 
             if hcrc != orig_hdr_crc:
                 raise RuntimeError(f"Journal corrupted: Header CRC mismatch (original: "
                                    f"{orig_hdr_crc:x}, recalculated: {hcrc:x}) for record "
-                                   f"{record_index} which began at file offset {record_start}")
+                                   f"{rpos.record_index} which began at file offset "
+                                   f"{rpos.record_start}")
 
             # Read the record body:
             bcrc = 0  # body CRC
@@ -352,23 +458,25 @@ class PublicationJournal:
                 if rec_len < required_body_len:
                     raise RuntimeError(f"Journal corrupted: Claimed record body length ({rec_len}) "
                                        f"too small to conain required data for record "
-                                       f"{record_index} which began at file offset {record_start}")
+                                       f"{rpos.record_index} which began at file offset "
+                                       f"{rpos.record_start}")
 
-                raw_seq_num = read(self.int_size, "message sequence number")
+                raw_seq_num = read(journal, rpos, self.int_size, "message sequence number")
                 seq_num, bcrc = decode(raw_seq_num, decode_int, bcrc, "sequence number")
 
-                raw_msg_len = read(self.int_size, "record message length")
+                raw_msg_len = read(journal, rpos, self.int_size, "record message length")
                 msg_len, bcrc = decode(raw_msg_len, decode_int, bcrc, "message length")
                 if msg_len > (rec_len - required_body_len):
                     raise RuntimeError(f"Journal corrupted: Claimed message data length ({msg_len})"
-                                       f" exceeds record body length for record {record_index} "
-                                       f"which began at file offset {record_start}")
+                                       f" exceeds record body length for record "
+                                       f"{rpos.record_index} which began at file offset "
+                                       f"{rpos.record_start}")
                 required_body_len += msg_len
 
-                message_data = read(msg_len, "record message data")
+                message_data = read(journal, rpos, msg_len, "record message data")
                 bcrc = zlib.crc32(message_data, bcrc) & 0xFFFFFFFF
 
-                raw_msg_hdr_cnt = read(self.int_size, "record message header count")
+                raw_msg_hdr_cnt = read(journal, rpos, self.int_size, "record message header count")
                 msg_hdr_cnt, bcrc = decode(raw_msg_hdr_cnt, decode_int, bcrc,
                                            "message header count")
                 # each header is described by a minimum of two encoded integers (key len and value
@@ -377,58 +485,26 @@ class PublicationJournal:
                 if 2 * self.int_size * msg_hdr_cnt > (rec_len - required_body_len):
                     raise RuntimeError(f"Journal corrupted: Claimed number of message headers "
                                        f"({msg_hdr_cnt}) exceeds remaining space in record body for"
-                                       f" record {record_index} which began at file offset "
-                                       f"{record_start}")
+                                       f" record {rpos.record_index} which began at file offset "
+                                       f"{rpos.record_start}")
                 required_body_len += 2 * self.int_size * msg_hdr_cnt
 
                 message_headers = []
                 for i in range(0, msg_hdr_cnt):
-                    raw_key_len = read(self.int_size, "message header key length")
-                    key_len, bcrc = decode(raw_key_len, decode_int, bcrc,
-                                           "message header key length")
-                    if key_len > (rec_len - required_body_len):
-                        raise RuntimeError(f"Journal corrupted: Claimed message header key length "
-                                           f"({key_len}) exceeds remaining space in record body for"
-                                           f" record {record_index} which began at file offset "
-                                           f"{record_start}")
-                    required_body_len += key_len
-
-                    key = read(key_len, "message header key data")
-                    bcrc = zlib.crc32(key, bcrc) & 0xFFFFFFFF
-
-                    raw_val_len = read(self.int_size, "message header value length")
-                    val_len, bcrc = decode(raw_val_len, decode_int, bcrc,
-                                           "message header value length")
-                    if val_len > (rec_len - required_body_len):
-                        raise RuntimeError(f"Journal corrupted: Claimed message header value length"
-                                           f" ({val_len}) exceeds remaining space in record body "
-                                           f"for record {record_index} which began at file offset "
-                                           f"{record_start}")
-                    required_body_len += val_len
-
-                    val = read(val_len, "message header value data")
-                    bcrc = zlib.crc32(val, bcrc) & 0xFFFFFFFF
-
-                    # confluent kafka requires keys in the form of unicode strings
-                    try:
-                        key = key.decode("utf-8")
-                    except UnicodeError:
-                        raise RuntimeError(f"Journal corrupted: Message header key is not valid "
-                                           f"UTF-8 in record {record_index} which began at file "
-                                           f"offset {record_start}")
-
+                    key, val, bcrc, required_body_len = \
+                        read_header(journal, rpos, bcrc, required_body_len, rec_len)
                     message_headers.append((key, val))
 
                 if seq_num in self.messages_to_send:
                     raise RuntimeError("Journal corrupted: Duplicate message sequence number in "
-                                       f"record {record_index} which began "
-                                       f"at file offset {record_start}")
+                                       f"record {rpos.record_index} which began "
+                                       f"at file offset {rpos.record_start}")
                 self.messages_to_send[seq_num] = (message_data, message_headers)
                 if self.message_counter <= seq_num:
                     self.message_counter = seq_num + 1
 
             elif rec_type == PublicationJournal.sent_record_type:
-                raw_seq_num = read(self.int_size, "message sequence number")
+                raw_seq_num = read(journal, rpos, self.int_size, "message sequence number")
                 seq_num, bcrc = decode(raw_seq_num, decode_int, bcrc, "sequence number")
 
                 if seq_num in self.messages_to_send:
@@ -436,18 +512,18 @@ class PublicationJournal:
                 else:
                     raise RuntimeError("Journal corrupted: Record of sent message ("
                                        f"{seq_num} which did not previously appear, in "
-                                       f"record {record_index} which began "
-                                       f"at file offset {record_start}")
+                                       f"record {rpos.record_index} which began "
+                                       f"at file offset {rpos.record_start}")
             else:
                 raise RuntimeError(f"Journal corrupted: Invalid record type ({rec_type}) "
                                    f"at file offset {record_type_offset}")
 
             if bcrc != orig_body_crc:
                 raise RuntimeError(f"Journal corrupted: CRC mismatch (original: {orig_body_crc:x}, "
-                                   f"recalculated: {bcrc:x}) for record {record_index} which began "
-                                   f"at file offset {record_start}")
+                                   f"recalculated: {bcrc:x}) for record {rpos.record_index} which "
+                                   f"began at file offset {rpos.record_start}")
 
-            record_index += 1
+            rpos.record_index += 1
 
     class NullLock:
         """A trivial context manager-compatible class which can be used in place of a lock when no

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -23,7 +23,7 @@ class _RAPriorityQueue:
     Items' keys are also their priorities, and keys which compare lower have higher priority.
 
     All keys in a queue must be mutually comparable; this is most easily accomplished by using a single
-    key type for a given queue. e
+    key type for a given queue.
     """
 
     def __init__(self):
@@ -161,7 +161,7 @@ class PublicationJournal:
             # The body length is contained in the header, and protected by the header CRC
             # so that item lengths within the body can be sanity checked before reading the
             # body is complete. The body CRC also protects the data in the body, but cannot
-            # be re-checked until the entrie body has been read. That can pose a problem if
+            # be re-checked until the entire body has been read. That can pose a problem if
             # the length for one of the variable length components in the body is corrupted,
             # and would lead to read of a nonsensical length (exhausting memory or similar).
             write_to_header(PublicationJournal.encode_int(record_type))  # record type

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -22,8 +22,9 @@ class _RAPriorityQueue:
 
     Items' keys are also their priorities, and keys which compare lower have higher priority.
 
-    All keys in a queue must be mutually comparable; this is most easily accomplished by using a single
-    key type for a given queue.
+    All keys in a queue must be mutually comparable; this is most easily accomplished by using a
+    single key type for a given queue.
+
     """
 
     def __init__(self):
@@ -484,8 +485,7 @@ class PublicationJournal:
                 self.requeue_message(seq_num)
 
     def get_delivery_callback(self, seq_num, lock=NullLock()):
-        """
-        Construct a callback handler specific to a particular message which will either mark it
+        """Construct a callback handler specific to a particular message which will either mark it
         successfully sent or requeue it to send again.
 
         The callback which is produced will take two arguments: A confluent_kafka.KafkaError
@@ -497,6 +497,7 @@ class PublicationJournal:
                      :meth:`get_next_message_to_send`.
             lock: An optional reference to a lock object which the callback should hold when
                   invoked, e.g. to protect concurrent access to the journal.
+
         """
         if seq_num not in self.maybe_sent_messages:
             raise RuntimeError("Cannot produce a delivery callback for message with sequence "
@@ -513,17 +514,16 @@ class PublicationJournal:
 
 class RobustProducer(threading.Thread):
     def __init__(self, url, auth=True, journal_path="publisher.journal", poll_wait=1.e-4, **kwargs):
-        """
-        Construct a publisher which will retry sending messages if it does not receive confirmation
+        """Construct a publisher which will retry sending messages if it does not receive confirmation
         that they have arrived, including if it is itself taken offline (i.e. crashes) for some
         reason.
 
         This is intended to provide *at least once* delivery of messages: If a message is confirmed
-        received by the broker, it will not be sent again, but if any disruption of the network or the
-        publisher itself prevents it from receiving that confirmation, even if the message was actually
-        received by the broker, the publisher will assume the worst and send the message again. Users of
-        this class (and more generally consumers of data published with it) should be prepared to discard
-        duplicate messages.
+        received by the broker, it will not be sent again, but if any disruption of the network or
+        the publisher itself prevents it from receiving that confirmation, even if the message was
+        actually received by the broker, the publisher will assume the worst and send the message
+        again. Users of this class (and more generally consumers of data published with it) should
+        be prepared to discard duplicate messages.
 
         Args:
             url: The URL for the Kafka topci to which messages will be published.
@@ -562,6 +562,7 @@ class RobustProducer(threading.Thread):
         Raises:
             OSError: If a journal file exists but cannot be read.
             Runtime Error: If the contents of the journal file are corrupted.
+
         """
         super(RobustProducer, self).__init__()
 
@@ -581,9 +582,9 @@ class RobustProducer(threading.Thread):
                                   **kwargs)
 
     def run(self):
-        """
-        This method is not part of the public interface of this class, and should not be called directly
+        """This method is not part of the public interface of this class, and should not be called directly
         by users.
+
         """
         while True:
             with self._cond:
@@ -625,10 +626,10 @@ class RobustProducer(threading.Thread):
                 pass
 
     def write(self, message, headers=None):
-        """
-        Queue a message to be sent. Message sending occurs asynchronously on a background thread, so this
-        method returns immediately unless an error occurs queuing the message.
-        :meth:`RobustProducer.start <RobustProducer.start>` must be called prior to calling this method.
+        """Queue a message to be sent. Message sending occurs asynchronously on a background thread, so
+        this method returns immediately unless an error occurs queuing the message.
+        :meth:`RobustProducer.start <RobustProducer.start>` must be called prior to calling this
+        method.
 
         Args:
             message: A message to send.
@@ -637,6 +638,7 @@ class RobustProducer(threading.Thread):
         Raises:
             RuntimeError: If appending the new message to the on-disk journal fails.
             TypeError: If the message is not a suitable type.
+
         """
         message, headers = io.Producer.pack(message, headers)
         with self._cond:  # must hold the lock to manipulate journal
@@ -645,22 +647,22 @@ class RobustProducer(threading.Thread):
         logger.debug(f"Queued message with sequence number {seq_num} to be sent")
 
     def start(self):
-        """
-        Start the background communication thread used by the publisher to send messages.
-        This should be called prior to any calls to :meth:`RobustProducer.write <RobustProducer.write>`.
+        """Start the background communication thread used by the publisher to send messages. This should
+        be called prior to any calls to :meth:`RobustProducer.write <RobustProducer.write>`.
         This method should not be called more than once.
+
         """
         self._should_stop = False
         self._immediate_start = self._journal.has_messages_to_send()
         super(RobustProducer, self).start()
 
     def stop(self):
-        """
-        Stop the background communication thread used by the publisher to send messages. This method will
-        block until the thread completes, which includes sending all queued messages.
-        :meth:`RobustProducer.write <RobustProducer.write>` should not be called after this method has
-        been called.
+        """Stop the background communication thread used by the publisher to send messages. This method
+        will block until the thread completes, which includes sending all queued messages.
+        :meth:`RobustProducer.write <RobustProducer.write>` should not be called after this method
+        has been called.
         This method should not be called more than once.
+
         """
         logger.debug("Stopping publisher thread")
         with self._cond:

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python
+
+import heapq
+from io import BytesIO
+import logging
+import os
+import struct
+import threading
+import zlib
+
+from . import io
+
+import confluent_kafka
+from adc.errors import KafkaException
+
+
+logger = logging.getLogger("hop")
+
+
+class RAPriorityQueue:
+    """A priority queue which also allows random access to queued items.
+
+    Items' keys are also their priorities, and keys which compare lower have higher priority.
+    """
+
+    def __init__(self):
+        """Create an empty queue"""
+        self.priorities = []
+        self.data = {}
+
+    def __len__(self):
+        """Return: the number of items in the queue."""
+        assert len(self.data) == len(self.priorities)
+        return len(self.data)
+
+    def __contains__(self, key):
+        """Test whether an item with the given key/priority is present in the queue."""
+        return key in self.data
+
+    def insert(self, key, value):
+        """Add an item to the queue, or replace the existing item stored under the given key."""
+        self.data[key] = value
+        heapq.heappush(self.priorities, key)
+
+    def __setitem__(self, key, value):
+        """Add an item to the queue, or replace the existing item stored under the given key."""
+        self.insert(key, value)
+
+    def __getitem__(self, key):
+        """Fetch the item stored under the given key.
+
+        Raises: KeyError if the key does not exist.
+        """
+        return self.data[key]
+
+    def pop_highest_priority(self):
+        """Fetch the item with the highest priority (lowest key) currently in the queue,
+            and removes it from the queue.
+
+        Returns: The (key, value) tuple for the highest priority item in the queue, or None if the
+                 queue is empty.
+        """
+        if len(self.data) == 0:
+            return None
+        key = heapq.heappop(self.priorities)
+        value = self.data[key]
+        del self.data[key]
+        return (key, value)
+
+    def remove(self, key):
+        """Remove an item from the queue, regardless of its location.
+
+        Raises: KeyError if the key does not exist.
+        """
+        del self.data[key]
+        idx = self.priorities.index(key)
+        del self.priorities[idx]
+        heapq.heapify(self.priorities)
+
+    def __delitem__(self, key):
+        self.remove(key)
+
+
+def _ensure_bytes_like(thing):
+    """Force an object which may be string-like to be bytes-like
+
+    Args:
+        thing: something which might be a string or might already be encoded as bytes.
+
+    Return:
+        Either the original input object or the encoding of that object as bytes.
+    """
+    try:  # check whether thing is bytes-like
+        memoryview(thing)
+        return thing  # keep as-is
+    except TypeError:
+        return thing.encode("utf-8")
+
+
+class PublicationJournal:
+    """
+    An object which tracks the state of messages which are being sent, persists that state to disk,
+    and enables it to be restored if the program stops unexpectedly.
+    """
+
+    int_format = "!Q"
+    int_size = struct.calcsize(int_format)
+    crc_format = "!I"
+    crc_size = struct.calcsize(crc_format)
+    msg_record_type = 0
+    sent_record_type = 1
+
+    @staticmethod
+    def encode_int(value: int):
+        return(struct.pack(PublicationJournal.int_format, value))
+
+    @staticmethod
+    def decode_int(buffer: bytes):
+        return struct.unpack(PublicationJournal.int_format, buffer)[0]
+
+    @staticmethod
+    def encode_crc(crc: int):
+        return(struct.pack(PublicationJournal.crc_format, crc))
+
+    @staticmethod
+    def decode_crc(buffer: bytes):
+        return struct.unpack(PublicationJournal.crc_format, buffer)[0]
+
+    def __init__(self, journal_path="publisher.journal"):
+        """Prepare a journal, including loading any data previously persisted to disk.
+
+        Args:
+            journal_path: The filesystem path from/to which the journal data should be read/written.
+
+        Raises:
+            PermissionError: If existing journal file does not have suitable permissions.
+            RuntimeError: If existing journal data cannot be read.
+        """
+        self.journal_path = journal_path
+        # each queue will store (message, headers) tuples, keyed by sequence numbers
+        self.messages_to_send = RAPriorityQueue()
+        self.maybe_sent_messages = RAPriorityQueue()
+        self.message_counter = 0
+        self._read_previous_journal()
+        self.journal = open(self.journal_path, "ab")
+
+    def _write_record(self, record_type: int, record_body: bytes):
+        try:
+            body_crc = zlib.crc32(record_body, 0) & 0xFFFFFFFF
+            header_crc = 0
+
+            def write_to_header(data: bytes):
+                # update running checksum and write data
+                nonlocal header_crc
+                header_crc = zlib.crc32(data, header_crc) & 0xFFFFFFFF
+                self.journal.write(data)
+            # The header is a fixed length, so it can be read independent of its contents.
+            # The body length is contained in the header, and protected by the header CRC
+            # so that item lengths within the body can be sanity checked before reading the
+            # body is complete. The body CRC also protects the data in the body, but cannot
+            # be re-checked until the entrie body has been read. That can pose a problem if
+            # the length for one of the variable length components in the body is corrupted,
+            # and would lead to read of a nonsensical length (exhausting memory or similar).
+            write_to_header(PublicationJournal.encode_int(record_type))  # record type
+            write_to_header(PublicationJournal.encode_int(len(record_body)))  # body length
+            write_to_header(PublicationJournal.encode_crc(body_crc))  # body CRC
+            self.journal.write(PublicationJournal.encode_crc(header_crc))  # header CRC
+            self.journal.write(record_body)  # body
+            self.journal.flush()
+        except BaseException as e:
+            raise RuntimeError(f"Failed to append record to journal: {e}")
+
+    # returns the sequence number assigned to the message
+    def queue_message(self, message: bytes, headers=None):
+        """Record to the journal a message which is to be sent.
+
+        Args:
+            message: A message to send, encoded as a bytes-like object.
+            headers: Headers to be sent with the message, as a list of 2-tuples of bytes-like
+                     objects.
+
+        Returns:
+            The sequence number assigned to the message.
+            Sequence numbers are unique among all messages which are 'live' at the same time,
+            but will otherwise be recycled.
+
+        Raises:
+            RuntimeError: If appending the new message to the on-disk journal fails.
+            TypeError: If the message is not a suitable type (bytes)
+        """
+        message = _ensure_bytes_like(message)
+        assert self.message_counter not in self.messages_to_send
+        sequence_number = self.message_counter
+
+        rbody = BytesIO()
+        rbody.write(PublicationJournal.encode_int(sequence_number))
+        rbody.write(PublicationJournal.encode_int(len(message)))  # message size
+        rbody.write(message)  # message data
+        if headers is not None:
+            rbody.write(PublicationJournal.encode_int(len(headers)))  # number of headers
+            for header in headers:
+                # data must be encoded to be written
+                key = _ensure_bytes_like(header[0])
+                value = _ensure_bytes_like(header[1])
+                rbody.write(PublicationJournal.encode_int(len(key)))  # header key length
+                rbody.write(key)  # header key
+                rbody.write(PublicationJournal.encode_int(len(value)))  # header value length
+                rbody.write(value)  # header value
+        else:
+            rbody.write(PublicationJournal.encode_int(0))  # no headers
+        self._write_record(PublicationJournal.msg_record_type, rbody.getvalue())
+
+        self.messages_to_send[sequence_number] = (message, headers)
+        self.message_counter += 1
+        return sequence_number
+
+    def has_messages_to_send(self):
+        """Check whether there are messages queued for sending (which have either not been sent at
+            all, or for which all sending attempts so far have failed, causing them to be requeued).
+        """
+        return len(self.messages_to_send) > 0
+
+    def get_next_message_to_send(self):
+        """Fetch the next mesage which should be sent
+
+        Returns:
+            The next message in the form of a tuple of (seqeunce number, message, message headers),
+            or None if there are no messages currently needing to be sent.
+        """
+        if len(self.messages_to_send) == 0:
+            return None
+        result = self.messages_to_send.pop_highest_priority()
+        self.maybe_sent_messages[result[0]] = result[1]
+        # rearrange to be more friendly to downstream code
+        return (result[0], result[1][0], result[1][1])
+
+    def has_messages_in_flight(self):
+        """Check whether there are messages for which a sending attempt has been started,
+            but has not yet conclusively succeeded or failed
+        """
+        return len(self.maybe_sent_messages) > 0
+
+    def mark_message_sent(self, sequence_number):
+        """Mark a message as successfully sent, and removes it from further consideration.
+
+        Truncates and restarts the backing journal file if the number of messages in-flight and
+        waiting to be sent falls to zero, and restarts the sequence number assignment sequence.
+
+        Raises:
+            RuntimeError: If no message with the specifed sequence number is currently recorded as
+                being in-flight.
+        """
+        if sequence_number not in self.maybe_sent_messages:
+            raise RuntimeError("No record of message with sequence number " + str(sequence_number)
+                               + " being queued for sending")
+        self._write_record(PublicationJournal.sent_record_type,
+                           PublicationJournal.encode_int(sequence_number))
+        del self.maybe_sent_messages[sequence_number]
+        if len(self.messages_to_send) == 0 and len(self.maybe_sent_messages) == 0:
+            # take this opportunity to garbage collect the journal file
+            self.journal.close()
+            os.unlink(self.journal_path)
+            self.journal = open(self.journal_path, "wb")
+            self.message_counter = 0
+
+    def requeue_message(self, sequence_number):
+        """Record a message send attempt as having failed by moving the message back from the
+            in-flight pool to the queue of messages needing to be sent.
+
+        Raises:
+            RuntimeError: If no message with the specifed sequence number is currently recorded as
+                being in-flight.
+        """
+        if sequence_number not in self.maybe_sent_messages:
+            raise RuntimeError("No record of message with sequence number "
+                               f"{sequence_number} being queued for sending")
+        # nothing to record in journal, message was already written when first queued
+        message = self.maybe_sent_messages[sequence_number]
+        del self.maybe_sent_messages[sequence_number]
+        self.messages_to_send[sequence_number] = message
+
+    def _read_previous_journal(self):
+        """Reload journal data from a previous session from disk.
+
+        Raises:
+            PermissionError: If the journal file does not have suitable permissions.
+            RuntimeError: If a problem occurs reading or interpreting the stored journal data.
+        """
+        if not os.path.exists(self.journal_path):
+            return  # nothing to do!
+        journal = open(self.journal_path, "rb")
+        record_index = 0
+        record_start = 0
+        while True:
+            decode_int = PublicationJournal.decode_int
+            decode_crc = PublicationJournal.decode_crc
+
+            def read(size, name, allow_eof=False):
+                try:
+                    buffer = journal.read(size)
+                except Exception:
+                    raise RuntimeError(f"Journal corrupted: Unable to read {name}")
+                if len(buffer) == 0 and allow_eof:  # end of file
+                    return buffer, True
+                elif len(buffer) < size:
+                    raise RuntimeError("Journal corrupted: Unexpected end of file (unable to read "
+                                       f"{name}) during record {record_index} which began at file "
+                                       f"offset {record_start}")
+                if allow_eof:
+                    return buffer, False
+                return buffer
+
+            def decode(data, decoder, crc, name):
+                crc = zlib.crc32(data, crc) & 0xFFFFFFFF
+                return decoder(data), crc
+
+            record_start = journal.tell()
+
+            # Read the record header:
+            hcrc = 0  # header CRC
+            record_type_offset = journal.tell()
+            raw_rec_type, eof = read(self.int_size, "record type", allow_eof=True)
+            if eof:
+                break
+            rec_type, hcrc = decode(raw_rec_type, decode_int, hcrc, "record type")
+
+            raw_rec_len = read(self.int_size, "record body length")
+            rec_len, hcrc = decode(raw_rec_len, decode_int, hcrc, "record body length")
+
+            raw_orig_body_crc = read(self.crc_size, "record body CRC")
+            orig_body_crc, hcrc = decode(raw_orig_body_crc, decode_crc, hcrc, "record body CRC")
+
+            raw_orig_hdr_crc = read(self.crc_size, "record header CRC")
+            # don't update recalculated CRC with raw_orig_hdr_crc, since it did not include itself
+            orig_hdr_crc, _ = decode(raw_orig_hdr_crc, decode_crc, 0, "record header CRC")
+
+            if hcrc != orig_hdr_crc:
+                raise RuntimeError(f"Journal corrupted: Header CRC mismatch (original: "
+                                   f"{orig_hdr_crc:x}, recalculated: {hcrc:x}) for record "
+                                   f"{record_index} which began at file offset {record_start}")
+
+            # Read the record body:
+            bcrc = 0  # body CRC
+
+            if rec_type == PublicationJournal.msg_record_type:
+                # record must contain sequence number, message data len, number of mesasge headers
+                required_body_len = 3 * self.int_size
+                if rec_len < required_body_len:
+                    raise RuntimeError(f"Journal corrupted: Claimed record body length ({rec_len}) "
+                                       f"too small to conain required data for record "
+                                       f"{record_index} which began at file offset {record_start}")
+
+                raw_seq_num = read(self.int_size, "message sequence number")
+                seq_num, bcrc = decode(raw_seq_num, decode_int, bcrc, "sequence number")
+
+                raw_msg_len = read(self.int_size, "record message length")
+                msg_len, bcrc = decode(raw_msg_len, decode_int, bcrc, "message length")
+                if msg_len > (rec_len - required_body_len):
+                    raise RuntimeError(f"Journal corrupted: Claimed message data length ({msg_len})"
+                                       f" exceeds record body length for record {record_index} "
+                                       f"which began at file offset {record_start}")
+                required_body_len += msg_len
+
+                message_data = read(msg_len, "record message data")
+                bcrc = zlib.crc32(message_data, bcrc) & 0xFFFFFFFF
+
+                raw_msg_hdr_cnt = read(self.int_size, "record message header count")
+                msg_hdr_cnt, bcrc = decode(raw_msg_hdr_cnt, decode_int, bcrc,
+                                           "message header count")
+                # each header is described by a minimum of two encoded integers (key len and value
+                # len), so sanity check that the claimed number of headers would fit in the
+                # remaining space in the record
+                if 2 * self.int_size * msg_hdr_cnt > (rec_len - required_body_len):
+                    raise RuntimeError(f"Journal corrupted: Claimed number of message headers "
+                                       f"({msg_hdr_cnt}) exceeds remaining space in record body for"
+                                       f" record {record_index} which began at file offset "
+                                       f"{record_start}")
+                required_body_len += 2 * self.int_size * msg_hdr_cnt
+
+                message_headers = []
+                for i in range(0, msg_hdr_cnt):
+                    raw_key_len = read(self.int_size, "message header key length")
+                    key_len, bcrc = decode(raw_key_len, decode_int, bcrc,
+                                           "message header key length")
+                    if key_len > (rec_len - required_body_len):
+                        raise RuntimeError(f"Journal corrupted: Claimed message header key length "
+                                           f"({key_len}) exceeds remaining space in record body for"
+                                           f" record {record_index} which began at file offset "
+                                           f"{record_start}")
+                    required_body_len += key_len
+
+                    key = read(key_len, "message header key data")
+                    bcrc = zlib.crc32(key, bcrc) & 0xFFFFFFFF
+
+                    raw_val_len = read(self.int_size, "message header value length")
+                    val_len, bcrc = decode(raw_val_len, decode_int, bcrc,
+                                           "message header value length")
+                    if val_len > (rec_len - required_body_len):
+                        raise RuntimeError(f"Journal corrupted: Claimed message header value length"
+                                           f" ({val_len}) exceeds remaining space in record body "
+                                           f"for record {record_index} which began at file offset "
+                                           f"{record_start}")
+                    required_body_len += val_len
+
+                    val = read(val_len, "message header value data")
+                    bcrc = zlib.crc32(val, bcrc) & 0xFFFFFFFF
+
+                    # confluent kafka requires keys in the form of unicode strings
+                    try:
+                        key = key.decode("utf-8")
+                    except UnicodeError:
+                        raise RuntimeError(f"Journal corrupted: Message header key is not valid "
+                                           f"UTF-8 in record {record_index} which began at file "
+                                           f"offset {record_start}")
+
+                    message_headers.append((key, val))
+
+                if seq_num in self.messages_to_send:
+                    raise RuntimeError("Journal corrupted: Duplicate message sequence number in "
+                                       f"record {record_index} which began "
+                                       f"at file offset {record_start}")
+                self.messages_to_send[seq_num] = (message_data, message_headers)
+                if self.message_counter <= seq_num:
+                    self.message_counter = seq_num + 1
+
+            elif rec_type == PublicationJournal.sent_record_type:
+                raw_seq_num = read(self.int_size, "message sequence number")
+                seq_num, bcrc = decode(raw_seq_num, decode_int, bcrc, "sequence number")
+
+                if seq_num in self.messages_to_send:
+                    del self.messages_to_send[seq_num]
+                else:
+                    raise RuntimeError("Journal corrupted: Record of sent message ("
+                                       f"{seq_num} which did not previously appear, in "
+                                       f"record {record_index} which began "
+                                       f"at file offset {record_start}")
+            else:
+                raise RuntimeError(f"Journal corrupted: Invalid record type ({rec_type}) "
+                                   f"at file offset {record_type_offset}")
+
+            if bcrc != orig_body_crc:
+                raise RuntimeError(f"Journal corrupted: CRC mismatch (original: {orig_body_crc:x}, "
+                                   f"recalculated: {bcrc:x}) for record {record_index} which began "
+                                   f"at file offset {record_start}")
+
+            record_index += 1
+
+    class NullLock:
+        """A trivial context manager-compatible class which can be used in place of a lock when no
+        locking is needed."""
+
+        def __init__(self):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_value, exc_traceback):
+            pass
+
+    def _delivery_callback(self,
+                           kafka_error: confluent_kafka.KafkaError,
+                           msg: confluent_kafka.Message,
+                           seq_num: int,
+                           lock):
+        """Handle a callback from librdkafka indicating the outcome of sending a message by either
+            marking it successfully sent or requeuing it to send again.
+        """
+        if kafka_error is None and msg.error() is None:
+            logger.debug(f"Message with sequence number {seq_num} was confirmed sent in "
+                         f"{msg.latency()} seconds")
+            with lock:
+                self.mark_message_sent(seq_num)
+        else:
+            err = kafka_error
+            if err is None:
+                err = msg.error()
+            logger.error("Error delivering message with sequence number: %i: "
+                         "%s; requeuing to send again", seq_num, err)
+            with lock:
+                self.requeue_message(seq_num)
+
+    def get_delivery_callback(self, seq_num, lock=NullLock()):
+        """Construct a callback handler specific to a particular message which will either mark it
+            successfully sent or requeue it to send again.
+
+            The callback which is produced will take two arguments: A confluent_kafka.KafkaError
+            describing any error in sending the message, and confluent_kafka.Message containing the
+            message itself.
+
+        Args:
+            seq_num: The sequence number of the message in question, previously returned by
+                     :meth:`get_next_message_to_send`.
+            lock: An optional refereence to a lock object which the callback should hold when
+                  invoked, e.g. to protect concurrent access to the journal.
+        """
+        if seq_num not in self.maybe_sent_messages:
+            raise RuntimeError("Cannot produce a delivery callback for message with sequence "
+                               f"number {seq_num} which is not in flight")
+        return lambda err, msg: self._delivery_callback(err, msg, seq_num, lock)
+
+    # adc.errors.log_client_errors is dangerous as it throws exceptions
+    # which will trigger https://github.com/confluentinc/confluent-kafka-python/issues/729
+    @staticmethod
+    def error_callback(kafka_error: confluent_kafka.KafkaError):
+        """A safe callback handler for reporting Kafka errors."""
+        logger.error(f"Kafka error: {kafka_error}")
+
+
+class RobustPublisher(threading.Thread):
+    def __init__(self, url, auth=True, journal_path="publisher.journal", poll_wait=1.e-4, **kwargs):
+        """
+        Construct a publisher which will retry sending messages if it does not receive confirmation
+        that they have arrived, including if it is itself taken offline (i.e. crashes) for some
+        reason.
+
+        Args:
+            url: The URL for the Kafka topci to which messages will be published.
+            auth: A `bool` or :class:`Auth <hop.auth.Auth>` instance. Defaults to
+                  loading from :meth:`auth.load_auth <hop.auth.load_auth>` if set to
+                  True. To disable authentication, set to False.
+            journal_path: The path on the filesystem where the messages being sent should be
+                          recorded until they are known to have been successfully received. This
+                          path should be located somewhere that will survive system restarts, and if
+                          messages contain sensitive data it should be noted that they will be
+                          written unencrypted to this path. The journal size is generally limited to
+                          the sum of sizes of messages queued for sending or in flight at the same
+                          time, plus some small (few tens of bytes per message) bookkeeping
+                          overhead. Note that this size can become large is a lengthy network
+                          disruption prev ents messages from being sent; enough disk spacec should
+                          be available to cover this possibility for the expected message rate and
+                          duration of disruptions which may need to be handled.
+            poll_wait: The time the publisher should spend checking for receipt of each message
+                       directly after sending it. Tuning this parameter controls a tradeoff between
+                       low latency discovery of successful message delivery and throughput. If the
+                       time between sending messages is large compared to the latency for a message
+                       to be sent and for a confirmation of receipt to return, it is useful to
+                       increase this value so that the publisher will wait to discover that each
+                       message has been sent (in the success case) instead of sleeping and waiting
+                       for another message to send. If this value is 'too low' (much smaller than
+                       both the time for a mesage to be sent and acknowledged and the time for the
+                       next message to be ready for sending), the publisher will waste CPU time
+                       entering and exiting the internal function used to receive event
+                       notifications. If this value is too large (larger than or similar in size to
+                       the time between messages needing to be sent) throughput will be lost as time
+                       will be spent waiting to see if the previous message has been acknowledged
+                       which could be better spent getting the next message sent out. When in doubt,
+                       it is probably best to err on the side of choosing a small value.
+            kwargs: Any additional arguments to be passed to :meth:`hop.io.open <hop.io.open>`.
+
+        Raises:
+            OSError: If a journal file exists but cannot be read.
+            Runtime Error: If the contents of the journal file are corrupted.
+        """
+        super(RobustPublisher, self).__init__()
+
+        self._poll_wait = poll_wait
+
+        # read any messages left over from a previous run
+        self._journal = PublicationJournal(journal_path)
+        if self._journal.has_messages_to_send():
+            logger.info(f"Journal has {len(self._journal.messages_to_send)} "
+                        "left-over messages to send")
+
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+
+        dummy = io.Stream(auth=auth)
+        self._stream = dummy.open(url, "w", error_callback=PublicationJournal.error_callback,
+                                  **kwargs)
+
+        self._running = True
+        self._immediate_start = self._journal.has_messages_to_send()
+
+    def run(self):
+        while True:
+            with self._cond:
+                if not self._running and not self._journal.has_messages_to_send():
+                    break
+                if not self._immediate_start:
+                    self._cond.wait()  # wait for something to do
+                else:
+                    self._immediate_start = False
+            self._do_send()
+        self._stream.flush()
+
+    def _do_send(self):
+        journal = self._journal
+        # use this slightly awkward loop structure to reacquire the lock on each iteration so that
+        # other threads have a chance to take it
+        while True:
+            with self._lock:
+                busy = journal.has_messages_to_send() or journal.has_messages_in_flight()
+                if not busy:
+                    break  # no work to do for now
+                do_send = False
+                if journal.has_messages_to_send():
+                    seq_num, message, headers = journal.get_next_message_to_send()
+                    do_send = True
+            if do_send:
+                try:
+                    dc = journal.get_delivery_callback(seq_num, self._lock)
+                    logger.debug(f"Sending message with sequence number {seq_num}")
+                    self._stream.write_raw(message, headers=headers, delivery_callback=dc)
+                except KafkaException as e:
+                    logger.error(f"Error sending message with sequence number: {seq_num}: {e}"
+                                 "; requeuing to send again")
+                    with self._lock:
+                        journal.requeue_message(seq_num)
+            try:
+                self._stream._producer._producer.poll(self._poll_wait)
+            except KafkaException:
+                pass
+
+    def write(self, message, headers=None):
+        message, headers = io.Producer.pack(message, headers)
+        with self._cond:  # must hold the lock to manipulate journal
+            seq_num = self._journal.queue_message(message, headers)
+            self._cond.notify()  # wake up the sender loop if sleeping
+        logger.debug(f"Queued message with sequence number {seq_num} to be sent")
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, ex_type, ex_val, traceback):
+        logger.debug("Stopping publisher thread")
+        with self._cond:
+            self._running = False
+            self._cond.notify()  # wake up the sender loop
+        self.join()
+        self._stream.close()
+        return False  # propagate any exceptions

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -514,6 +514,13 @@ class RobustPublisher(threading.Thread):
         that they have arrived, including if it is itself taken offline (i.e. crashes) for some
         reason.
 
+        This is intended to provide *at least once* delivery of messages: If a message is confirmed
+        received by the broker, it will not be sent again, but if any disruption of the network or the
+        publisher itself prevents it from receiving that confirmation, even if the message was actually
+        received by the broker, the publisher will assume the worst and send the message again. Users of
+        this class (and more generally consumers of data published with it) should be prepared to discard
+        duplicate messages.
+
         Args:
             url: The URL for the Kafka topci to which messages will be published.
             auth: A `bool` or :class:`Auth <hop.auth.Auth>` instance. Defaults to

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -21,6 +21,9 @@ class RAPriorityQueue:
     """A priority queue which also allows random access to queued items.
 
     Items' keys are also their priorities, and keys which compare lower have higher priority.
+
+    All keys in a queue must be mutually comparable; this is most easily accomplished by using a single
+    key type for a given queue. e
     """
 
     def __init__(self):
@@ -491,7 +494,7 @@ class PublicationJournal:
         Args:
             seq_num: The sequence number of the message in question, previously returned by
                      :meth:`get_next_message_to_send`.
-            lock: An optional refereence to a lock object which the callback should hold when
+            lock: An optional reference to a lock object which the callback should hold when
                   invoked, e.g. to protect concurrent access to the journal.
         """
         if seq_num not in self.maybe_sent_messages:

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -1,0 +1,837 @@
+import errno
+from io import BytesIO
+import logging
+import os
+import pytest
+import stat
+import time
+import threading
+from unittest.mock import patch, MagicMock
+
+from adc.errors import KafkaException
+
+import hop
+from hop.robust_publisher import RAPriorityQueue, PublicationJournal, RobustPublisher
+
+
+logger = logging.getLogger("hop")
+
+
+def test_queue_construction():
+    q = RAPriorityQueue()
+    assert len(q) == 0  # queue should initially be empty
+
+
+def test_queue_len():
+    q = RAPriorityQueue()
+    expected = 0
+
+    def add(key, value):
+        nonlocal expected
+        q.insert(key, value)
+        expected += 1
+
+    def remove():
+        nonlocal expected
+        result = q.pop_highest_priority()
+        if result is not None:
+            expected -= 1
+
+    add(1, "a")
+    assert len(q) == expected
+    add(2, "b")
+    assert len(q) == expected
+    remove()
+    assert len(q) == expected
+    add(0, "c")
+    assert len(q) == expected
+    remove()
+    assert len(q) == expected
+    remove()
+    assert len(q) == expected
+    remove()
+    assert len(q) == expected
+
+
+def test_queue_contains():
+    q = RAPriorityQueue()
+    assert "foo" not in q
+    q.insert("foo", "bar")
+    assert "foo" in q
+    q.pop_highest_priority()
+    assert "foo" not in q
+    q.insert("baz", "quux")
+    q.insert("xen", "hom")
+    assert "baz" in q
+    assert "xen" in q
+
+
+def test_queue_insert_setitem():
+    q = RAPriorityQueue()
+    assert "foo" not in q
+    q.insert("foo", "bar")
+    assert "foo" in q
+    assert q["foo"] == "bar"
+    q.insert("foo", "baz")
+    assert q["foo"] == "baz"
+    q["foo"] = "quux"
+    assert q["foo"] == "quux"
+    q["bar"] = "xen"
+    assert q["bar"] == "xen"
+
+
+def test_queue_getitem():
+    q = RAPriorityQueue()
+    with pytest.raises(KeyError):
+        q["foo"]
+    q.insert("foo", "bar")
+    assert q["foo"] == "bar"
+    q.insert("baz", "quux")
+    assert q["foo"] == "bar"
+    assert q["baz"] == "quux"
+    q.pop_highest_priority()
+    assert q["foo"] == "bar"
+    with pytest.raises(KeyError):
+        q["baz"]
+
+
+def test_queue_pop():
+    q = RAPriorityQueue()
+    assert q.pop_highest_priority() is None
+    # if there is only one item, pop must remove it
+    q.insert(1, "foo")
+    assert q.pop_highest_priority() == (1, "foo")
+    # multiple items must be removed in priority order
+    q.insert(2, "bar")
+    q.insert(3, "baz")
+    q.insert(1, "foo")
+    assert q.pop_highest_priority() == (1, "foo")
+    assert q.pop_highest_priority() == (2, "bar")
+    assert q.pop_highest_priority() == (3, "baz")
+
+
+def test_queue_remove_del():
+    q = RAPriorityQueue()
+    with pytest.raises(KeyError):
+        q.remove(1)
+    q.insert(2, "bar")
+    q.insert(3, "baz")
+    q.insert(1, "foo")
+    q.remove(2)
+    assert 2 not in q
+    assert q.pop_highest_priority() == (1, "foo")
+    assert q.pop_highest_priority() == (3, "baz")
+    with pytest.raises(KeyError):
+        del q[1]
+    q.insert(2, "bar")
+    q.insert(3, "baz")
+    q.insert(1, "foo")
+    del q[1]
+    assert 1 not in q
+    assert q.pop_highest_priority() == (2, "bar")
+    assert q.pop_highest_priority() == (3, "baz")
+
+
+########################################
+
+
+def test_journal_construct_no_file(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+    assert not j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+    assert j.get_next_message_to_send() is None
+    assert os.path.exists(journal_path)
+
+
+def test_journal_construct_empty_file(tmpdir):
+    journal_path = tmpdir.join("journal")
+    open(journal_path, "ab")  # touch file
+    j = PublicationJournal(journal_path)
+    assert not j.has_messages_to_send()
+    assert j.get_next_message_to_send() is None
+    assert not j.has_messages_in_flight()
+    assert os.path.exists(journal_path)
+
+
+def test_journal_construct_bad_perms_file(tmpdir):
+    journal_path = tmpdir.join("journal")
+    open(journal_path, "ab")  # touch file
+    os.chmod(journal_path, stat.S_IWUSR)  # remove read permission
+    with pytest.raises(PermissionError):
+        j = PublicationJournal(journal_path)
+
+
+def test_journal_queue_message(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    j.queue_message(b"message 0")
+    assert j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+    s0 = j.get_next_message_to_send()
+    assert s0[1] == b"message 0"
+    assert not j.has_messages_to_send()
+    assert j.has_messages_in_flight()
+
+    headers = [(b"header_0", b"value_0"), (b"header_1", b"value_1")]
+    j.queue_message(b"message 1", headers=headers)
+    assert j.has_messages_to_send()
+    s1 = j.get_next_message_to_send()
+    assert not j.has_messages_to_send()
+    assert s1[1] == b"message 1"
+    assert s1[2] == headers
+
+
+def test_journal_queue_message_write_failure(tmpdir):
+    def write_fail(*args, **kwargs):
+        raise OSError(errno.EIO, os.strerror(errno.EIO))
+    file_mock = MagicMock()
+    file_mock.write = write_fail
+    file_mock.__enter__ = MagicMock(return_value=file_mock)
+    open_mock = MagicMock(return_value=file_mock)
+
+    journal_path = tmpdir.join("journal")
+    with patch("builtins.open", open_mock):
+        j = PublicationJournal(journal_path)
+        with pytest.raises(RuntimeError) as excinfo:
+            j.queue_message(b"some data")
+        assert "Failed to append record to journal" in str(excinfo.value)
+
+
+def test_journal_mark_sent(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    j.queue_message(b"message 0")
+    assert j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+    s0 = j.get_next_message_to_send()
+    assert s0[1] == b"message 0"
+    assert j.has_messages_in_flight()
+
+    j.mark_message_sent(s0[0])
+    assert not j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+    with pytest.raises(RuntimeError):
+        j.mark_message_sent(s0[0])  # can't mark the same message sent twice
+
+    j.queue_message(b"message 1")
+    j.queue_message(b"message 2")
+    assert j.has_messages_to_send()
+
+    with pytest.raises(RuntimeError):
+        j.mark_message_sent(1)  # can't mark things sent that haven't been extracted
+
+    s1 = j.get_next_message_to_send()
+    s2 = j.get_next_message_to_send()
+    assert not j.has_messages_to_send()
+    assert j.has_messages_in_flight()
+
+    # can mark messages sent out of order
+    j.mark_message_sent(s2[0])
+    assert j.has_messages_in_flight()
+    j.mark_message_sent(s1[0])
+    assert not j.has_messages_in_flight()
+
+
+def test_journal_mark_sent_write_failure(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+    j.queue_message(b"message 0")
+    del j
+
+    def write_fail(*args, **kwargs):
+        raise OSError(errno.EIO, os.strerror(errno.EIO))
+    file_mock = MagicMock()
+    file_mock.write = write_fail
+    file_mock.__enter__ = MagicMock(return_value=file_mock)
+    orig_open = open
+    # allow reading to proceed normally so we can read the existing journal,
+    # but intercept writing to inject failures
+
+    def sneaky_open(path, mode, *args, **kwargs):
+        if 'r' in mode:
+            return orig_open(path, mode, *args, **kwargs)
+        else:
+            return file_mock
+
+    with patch("builtins.open", wraps=sneaky_open):
+        j = PublicationJournal(journal_path)
+        s = j.get_next_message_to_send()
+        with pytest.raises(RuntimeError) as excinfo:
+            j.mark_message_sent(s[0])
+        assert "Failed to append record to journal" in str(excinfo.value)
+
+
+def test_journal_requeue_message(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    with pytest.raises(RuntimeError):
+        j.requeue_message(0)  # can't requeue unknown messages
+
+    j.queue_message(b"message 0")
+    with pytest.raises(RuntimeError):
+        j.requeue_message(0)  # can't requeue unsent messages
+
+    s0 = j.get_next_message_to_send()
+    assert not j.has_messages_to_send()
+    assert j.has_messages_in_flight()
+    j.requeue_message(s0[0])
+    assert j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+    with pytest.raises(RuntimeError):
+        j.requeue_message(s0[0])  # can't requeue the same message twice at a time
+
+    s0_2 = j.get_next_message_to_send()
+    assert s0_2 == s0, "Message to be resent should match original"
+    j.mark_message_sent(s0_2[0])
+
+    with pytest.raises(RuntimeError):
+        j.requeue_message(s0[0])  # can't requeue a sent message
+
+
+def test_journal_restore_state(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    del j
+    j = PublicationJournal(journal_path)  # relaod empty journal
+    assert not j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+    m0 = b"message 0"
+    headers = [("header_0", b"value_0"), ("header_1", b"value_1")]
+    j.queue_message(m0, headers)
+    del j
+    j = PublicationJournal(journal_path)  # relaod with message to send
+    assert j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+    s0 = j.get_next_message_to_send()
+    assert s0[1] == m0, "Message body should be preserved by on-disk journal"
+    assert s0[2] == headers, "Message headers should be preserved by on-disk journal"
+    del j
+    j = PublicationJournal(journal_path)  # relaod with message in flight
+    # this may appear counter-intuitive, but if the journal/sender is offline while the message is
+    # in flight, we have no way of knowing whether it arrived. Therefore, the conservative thing to
+    # do is assume that it did not, and send it again.
+    assert j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+    s0_2 = j.get_next_message_to_send()
+    assert s0_2 == s0, "Message to be resent should match original"
+    j.mark_message_sent(s0_2[0])
+    del j
+    j = PublicationJournal(journal_path)  # relaod after message successfully sent
+    assert not j.has_messages_to_send()
+    assert not j.has_messages_in_flight()
+
+
+def test_journal_restore_state_corrupted(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    headers = [("header_0", b"value_0"), ("header_1", b"value_1")]
+    for i in range(0, 10):
+        message = f"message {i}".encode("utf-8")
+        if (i % 3) == 0:
+            j.queue_message(message, headers=headers)
+        else:
+            j.queue_message(message)
+
+    for i in range(0, 10):
+        m = j.get_next_message_to_send()
+        if (i % 2) == 0:
+            j.mark_message_sent(m[0])
+
+    del j
+    # capture the raw journal for later manipulation
+    with open(journal_path, "rb") as journal_file:
+        journal_data = journal_file.read()
+
+    # the unmodified journal should be readable
+    j = PublicationJournal(journal_path)
+    assert j.has_messages_to_send()
+    assert len(j.messages_to_send) == 5
+    assert not j.has_messages_in_flight()
+    del j
+
+    # test that corruption in any byte is detected
+    for i in range(0, len(journal_data)):
+        corrupted_data = bytearray(journal_data)
+        corrupted_data[i] ^= 0b01010101  # flip some bits
+        with open(journal_path, "wb") as journal_file:
+            journal_file.write(corrupted_data)
+        with pytest.raises(RuntimeError):
+            try:
+                j = PublicationJournal(journal_path)
+            except RuntimeError as e:
+                print(i, e)
+                raise
+
+    # test that invalid unicode in message header keys is detected
+    corrupted_data = bytearray(journal_data).replace(b"header_0",
+                                                     b"\xc3\x28\xa0\xa1\xf0\x28\x8c\xbc")
+    with open(journal_path, "wb") as journal_file:
+        journal_file.write(corrupted_data)
+    with pytest.raises(RuntimeError):
+        try:
+            j = PublicationJournal(journal_path)
+        except RuntimeError as e:
+            print("invalid unicode message header", e)
+            raise
+
+
+def test_journal_restore_state_truncated(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    headers = [(b"header_0", b"value_0"), (b"header_1", b"value_1")]
+    for i in range(0, 10):
+        message = f"message {i}".encode("utf-8")
+        if (i % 3) == 0:
+            j.queue_message(message, headers=headers)
+        else:
+            j.queue_message(message)
+
+    for i in range(0, 10):
+        m = j.get_next_message_to_send()
+        if (i % 2) == 0:
+            j.mark_message_sent(m[0])
+
+    del j
+    # capture the raw journal for later manipulation
+    with open(journal_path, "rb") as journal_file:
+        journal_data = journal_file.read()
+
+    # these are the offsets of the ends of the records
+    # if the file format or test data is changed, these must be updated
+    # truncating the file between records is valid/undetectable, so we should not test these
+    valid_break_points = [119, 176, 233, 352, 409, 466, 585, 642, 699, 818,
+                          850, 882, 914, 946, 978]
+    # test that truncation at any byte (in a record) is detected
+    for i in range(1, len(journal_data)):
+        if i in valid_break_points:
+            continue
+        with open(journal_path, "wb") as journal_file:
+            journal_file.write(journal_data[0:i])
+        with pytest.raises(RuntimeError):
+            try:
+                j = PublicationJournal(journal_path)
+            except RuntimeError as e:
+                print(i, e)
+                raise
+            print(f"Failure: Truncation at byte {i} should be detected")
+
+
+def test_journal_restore_duplicate_sequence_number_to_send(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # directly use internal recording function to generate records with valid checksums
+    # but dubious meanings
+    test_message = b"data"
+    rbody = BytesIO()
+    rbody.write(PublicationJournal.encode_int(0))  # sequence number
+    rbody.write(PublicationJournal.encode_int(len(test_message)))  # data length
+    rbody.write(test_message)  # data
+    rbody.write(PublicationJournal.encode_int(0))  # no headers
+    j._write_record(PublicationJournal.msg_record_type, rbody.getvalue())
+    # record the same message again, duplicating the sequence number
+    j._write_record(PublicationJournal.msg_record_type, rbody.getvalue())
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert "Duplicate message sequence number" in str(excinfo.value)
+
+
+def test_journal_restore_too_short_message_record(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # a message record must contain the sequence number, mesage length, an header count
+    # requiring 3*8 = 24 bytes. Anything shorter cannot be valid.
+    j._write_record(PublicationJournal.msg_record_type, b"tooshort")
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert "too small to conain required data for record" in str(excinfo.value)
+
+
+def test_journal_restore_missing_headers(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # directly use internal recording function to generate records with valid checksums
+    # but dubious meanings
+    test_message = b"data"
+    rbody = BytesIO()
+    rbody.write(PublicationJournal.encode_int(0))  # sequence number
+    rbody.write(PublicationJournal.encode_int(len(test_message)))  # data length
+    rbody.write(test_message)  # data
+    # claim a bunch of headers, but then don't include any
+    rbody.write(PublicationJournal.encode_int(56))
+    j._write_record(PublicationJournal.msg_record_type, rbody.getvalue())
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert "Claimed number of message headers" in str(excinfo.value)
+    assert "exceeds remaining space in record body" in str(excinfo.value)
+
+
+def test_journal_restore_sent_unknown_sequence_number(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # directly use internal recording function to generate records with valid checksums
+    # but dubious meanings
+    # record that a message was sent without it being previously mentioned
+    j._write_record(PublicationJournal.sent_record_type, PublicationJournal.encode_int(56))
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert "Record of sent message" in str(excinfo.value)
+    assert "which did not previously appear" in str(excinfo.value)
+
+
+def test_journal_restore_duplicate_send(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # directly use internal recording function to generate records with valid checksums
+    # but dubious meanings
+    test_message = b"data"
+    rbody = BytesIO()
+    rbody.write(PublicationJournal.encode_int(17))  # sequence number
+    rbody.write(PublicationJournal.encode_int(len(test_message)))  # data length
+    rbody.write(test_message)  # data
+    rbody.write(PublicationJournal.encode_int(0))  # no headers
+    j._write_record(PublicationJournal.msg_record_type, rbody.getvalue())
+    # record that the message was sent
+    j._write_record(PublicationJournal.sent_record_type, PublicationJournal.encode_int(17))
+    # record that the message was sent _again_
+    j._write_record(PublicationJournal.sent_record_type, PublicationJournal.encode_int(17))
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert "Record of sent message" in str(excinfo.value)
+    assert "which did not previously appear" in str(excinfo.value)
+
+
+def test_journal_restore_duplicate_bogus_record_type(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+    # use a record type which is not defined
+    bogus_record_type = 46000
+    j._write_record(bogus_record_type, b"irrelevant")
+    del j
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j = PublicationJournal(journal_path)
+    assert f"Invalid record type ({bogus_record_type})" in str(excinfo.value)
+
+
+def test_journal_restore_read_failure(tmpdir):
+    def read_fail(*args, **kwargs):
+        raise OSError(errno.EIO, os.strerror(errno.EIO))
+    file_mock = MagicMock()
+    file_mock.read = read_fail
+    file_mock.__enter__ = MagicMock(return_value=file_mock)
+    open_mock = MagicMock(return_value=file_mock)
+
+    journal_path = tmpdir.join("journal")
+    with open(journal_path, 'w'):
+        pass  # touch the file
+    with patch("builtins.open", open_mock):
+        with pytest.raises(RuntimeError) as excinfo:
+            j = PublicationJournal(journal_path)
+        assert "Journal corrupted: Unable to read" in str(excinfo.value)
+
+
+def test_journal_get_delivery_callback_unqueued_message(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    # can't get a callback for a message which isn't yet queued
+    with pytest.raises(RuntimeError) as excinfo:
+        j.get_delivery_callback(22)
+    assert "Cannot produce a delivery callback for message" in str(excinfo.value)
+    assert "which is not in flight" in str(excinfo.value)
+
+    # can't get a callback for a message which has already been sent
+    j.queue_message(b"message 0")
+    s0 = j.get_next_message_to_send()
+    j.mark_message_sent(s0[0])
+
+    with pytest.raises(RuntimeError) as excinfo:
+        j.get_delivery_callback(s0[0])
+    assert "Cannot produce a delivery callback for message" in str(excinfo.value)
+    assert "which is not in flight" in str(excinfo.value)
+
+
+def test_journal_delivery_callback_mark_sent(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    j.queue_message(b"message 0")
+    s0 = j.get_next_message_to_send()
+    callback = j.get_delivery_callback(s0[0])
+    assert j.has_messages_in_flight()
+
+    msg_obj = MagicMock()
+    msg_obj.error = MagicMock(return_value=None)  # indicate no error if asked
+    callback(None, msg_obj)  # no error and the 'message'
+    assert not j.has_messages_in_flight()
+
+
+def test_journal_delivery_callback_requeue(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    j.queue_message(b"message 0")
+    s0 = j.get_next_message_to_send()
+    callback = j.get_delivery_callback(s0[0])
+    assert j.has_messages_in_flight()
+    assert not j.has_messages_to_send()
+
+    msg_obj = MagicMock()
+    msg_obj.error = MagicMock(return_value="bad!")  # some error message
+
+    # invoking the callback with an error should cause the message to be requeued
+    callback("disaster", msg_obj)  # an error and the 'message'
+    assert not j.has_messages_in_flight()
+    assert j.has_messages_to_send()
+
+    s0 = j.get_next_message_to_send()  # pretend we're retrying to send
+
+    callback(None, msg_obj)  # no direct error, but the 'message' contains one
+    assert not j.has_messages_in_flight()
+    assert j.has_messages_to_send()
+
+
+class TrialLock():
+    def __init__(self):
+        self.held = False
+        self.was_locked = False
+
+    def __enter__(self):
+        assert not self.held
+        self.held = True
+        self.was_locked = True
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        assert self.held
+        self.held = False
+
+
+def test_journal_delivery_callback_locking(tmpdir):
+    journal_path = tmpdir.join("journal")
+    j = PublicationJournal(journal_path)
+
+    myLock = TrialLock()
+
+    def wrap(func):
+        def require_lock(*args, **kwargs):
+            assert myLock.held, "Lock must be held for this operation"
+            return func(*args, **kwargs)
+        return require_lock
+
+    j.queue_message(b"message 0")
+    s0 = j.get_next_message_to_send()
+    callback = j.get_delivery_callback(s0[0], myLock)
+
+    msg_obj = MagicMock()
+    msg_obj.error = MagicMock(return_value=None)
+
+    with patch("hop.robust_publisher.PublicationJournal.mark_message_sent",
+               wrap(PublicationJournal.mark_message_sent)), \
+            patch("hop.robust_publisher.PublicationJournal.requeue_message",
+                  wrap(PublicationJournal.requeue_message)):
+        assert not myLock.was_locked
+        callback("error!", msg_obj)  # simulate sending failure
+        assert not myLock.held, "Lock should be released"
+        assert myLock.was_locked, "Lock should have been held"
+
+        # 'get' the message to send again
+        s0_2 = j.get_next_message_to_send()
+        assert s0_2[0] == s0[0]
+
+        myLock.was_locked = False
+        callback(None, msg_obj)  # simulate sending success
+        assert not myLock.held, "Lock should be released"
+        assert myLock.was_locked, "Lock should have been held"
+
+
+def test_journal_error_callback():
+    # this is just required to not throw
+    PublicationJournal.error_callback("terrible error!")
+
+
+########################################
+
+
+def makeKafkaException(name="error_name", reason="error reason"):
+    err = MagicMock()
+    err.name = MagicMock(return_value=name)
+    err.reason = MagicMock(return_value=reason)
+    err.retriable = MagicMock(return_value=True)
+    err.fatal = MagicMock(return_value=False)
+    return KafkaException(err)
+
+
+class FakeProducer:
+    def __init__(self, immediate_failure=False, poll_failure=False):
+        self.delivery_callbacks = []
+        self.messages_written = []
+        # need to coordinate access due to RobustPublisher's background thread
+        self.lock = threading.Lock()
+        # need this to allow ._producer._producer.poll()
+        self._producer = MagicMock()
+        self._producer._producer = MagicMock()
+        if poll_failure:
+            logger.debug("poll should fail")
+            exc = makeKafkaException()
+
+            def fail_poll(delay):
+                time.sleep(delay)
+                raise exc
+
+            self._producer._producer.poll = fail_poll
+            logger.debug(f" poll is {self._producer._producer.poll}")
+        self._immediate_failure = immediate_failure
+
+    def invoke_all_callbacks(self, err, msg):
+        with self.lock:
+            for callback in self.delivery_callbacks:
+                callback(err, msg)
+            self.delivery_callbacks.clear()
+
+    def write_raw(self, packed_message, headers, delivery_callback):
+        logger.debug(f" FakeProducer.write_raw called with {packed_message}, {headers}")
+        if self._immediate_failure:
+            self._immediate_failure = False  # stop failing after the first time
+            raise makeKafkaException()
+        with self.lock:
+            self.messages_written.append((packed_message, headers))
+            self.delivery_callbacks.append(delivery_callback)
+
+    def flush(self):
+        logger.debug(f" FakeProducer.flush called with {len(self.delivery_callbacks)} "
+                     "callback(s) in queue")
+        # simulate any remaining messages being sent successfully
+        msg_no_err = MagicMock()
+        msg_no_err.error = MagicMock(return_value=None)
+        msg_no_err.latency = MagicMock(return_value=0.1)
+        self.invoke_all_callbacks(None, msg_no_err)
+
+    def close(self):
+        logger.debug(" FakeProducer.close called")
+        self.flush()
+
+    def stop_failing_poll(self):
+        self._producer._producer.poll = MagicMock(return_value=None)
+
+
+# build pointless layers surrounding the hop.io.Producer class
+def makeStream(*args, **kwargs):
+    opener = MagicMock()
+    opener.open = MagicMock(return_value=FakeProducer(*args, **kwargs))
+    return MagicMock(return_value=opener)
+
+
+def test_rpublisher_empty_journal(tmpdir):
+    journal_path = tmpdir.join("journal")
+    url = "kafka://example.com/topic"
+
+    with patch("hop.io.Stream", makeStream()) as steam_middleman:
+        with RobustPublisher(url, journal_path=journal_path) as pub:
+            pub.write("a message")
+
+            # The publisher will spin in _do_send as long as the state of sent messages is
+            # indeterminate. So, spin here in a thread-safe way until the callbacks show up, then
+            # invoke them to let it complete.
+            while True:
+                time.sleep(0.01)
+                with pub._stream.lock:
+                    msg_count = len(pub._stream.messages_written)
+                if msg_count == 1:
+                    pub._stream.flush()
+                    break
+        assert hop.io.Producer.pack("a message", None) in pub._stream.messages_written
+
+
+def test_rpublisher_existing_journal(tmpdir):
+    journal_path = tmpdir.join("journal")
+    url = "kafka://example.com/topic"
+    messages = [b"message 0", b"message 1"]
+
+    j = PublicationJournal(journal_path)
+    for message in messages:
+        j.queue_message(message)
+    del j
+
+    with patch("hop.io.Stream", makeStream()) as steam_middleman:
+        with RobustPublisher(url, journal_path=journal_path) as pub:
+            while True:
+                time.sleep(0.01)
+                with pub._stream.lock:
+                    msg_count = len(pub._stream.messages_written)
+                if msg_count == 2:
+                    pub._stream.flush()
+                    break
+        # each message previously persisted in the journal should be sent
+        sent_messages = [item[0] for item in pub._stream.messages_written]
+        for message in messages:
+            assert message in sent_messages
+
+
+def test_rpublisher_immediate_send_fail(tmpdir):
+    journal_path = tmpdir.join("journal")
+    url = "kafka://example.com/topic"
+
+    with patch("hop.io.Stream", makeStream(immediate_failure=True)) as steam_middleman:
+        with RobustPublisher(url, journal_path=journal_path) as pub:
+            pub.write("a message")
+
+            while True:
+                time.sleep(0.01)
+                with pub._stream.lock:
+                    msg_count = len(pub._stream.messages_written)
+                if msg_count == 1:
+                    pub._stream.flush()
+                    break
+        assert hop.io.Producer.pack("a message", None) in pub._stream.messages_written
+
+
+def test_rpublisher_poll_fail(tmpdir):
+    print("test_rpublisher_poll_fail")
+    journal_path = tmpdir.join("journal")
+    url = "kafka://example.com/topic"
+
+    with patch("hop.io.Stream", makeStream(poll_failure=True)) as steam_middleman:
+        with RobustPublisher(url, journal_path=journal_path) as pub:
+            pub.write("a message")
+
+            while True:
+                logger.debug("wating for message to be sent")
+                time.sleep(0.01)
+                with pub._stream.lock:
+                    msg_count = len(pub._stream.messages_written)
+                if msg_count == 1:
+                    logger.debug("message is visible, waiting to allow poll to proceed")
+                    time.sleep(0.01)
+                    logger.debug("stopping poll failures")
+                    pub._stream.stop_failing_poll()
+                    pub._stream.flush()
+                    break
+            logger.debug("with body done")
+        assert hop.io.Producer.pack("a message", None) in pub._stream.messages_written

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -252,10 +252,10 @@ def test_journal_mark_sent_write_failure(tmpdir):
     # but intercept writing to inject failures
 
     def sneaky_open(path, mode, *args, **kwargs):
-        if 'r' in mode:
-            return orig_open(path, mode, *args, **kwargs)
-        else:
+        if 'w' in mode or 'a' in mode:
             return file_mock
+        else:
+            return orig_open(path, mode, *args, **kwargs)
 
     with patch("builtins.open", wraps=sneaky_open):
         j = PublicationJournal(journal_path)

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -299,7 +299,7 @@ def test_journal_restore_state(tmpdir):
     j = PublicationJournal(journal_path)
 
     del j
-    j = PublicationJournal(journal_path)  # relaod empty journal
+    j = PublicationJournal(journal_path)  # reload empty journal
     assert not j.has_messages_to_send()
     assert not j.has_messages_in_flight()
 
@@ -307,7 +307,7 @@ def test_journal_restore_state(tmpdir):
     headers = [("header_0", b"value_0"), ("header_1", b"value_1")]
     j.queue_message(m0, headers)
     del j
-    j = PublicationJournal(journal_path)  # relaod with message to send
+    j = PublicationJournal(journal_path)  # reload with message in queue
     assert j.has_messages_to_send()
     assert not j.has_messages_in_flight()
 
@@ -315,7 +315,7 @@ def test_journal_restore_state(tmpdir):
     assert s0[1] == m0, "Message body should be preserved by on-disk journal"
     assert s0[2] == headers, "Message headers should be preserved by on-disk journal"
     del j
-    j = PublicationJournal(journal_path)  # relaod with message in flight
+    j = PublicationJournal(journal_path)  # reload with message in flight
     # this may appear counter-intuitive, but if the journal/sender is offline while the message is
     # in flight, we have no way of knowing whether it arrived. Therefore, the conservative thing to
     # do is assume that it did not, and send it again.
@@ -326,7 +326,7 @@ def test_journal_restore_state(tmpdir):
     assert s0_2 == s0, "Message to be resent should match original"
     j.mark_message_sent(s0_2[0])
     del j
-    j = PublicationJournal(journal_path)  # relaod after message successfully sent
+    j = PublicationJournal(journal_path)  # reload after message successfully sent
     assert not j.has_messages_to_send()
     assert not j.has_messages_in_flight()
 


### PR DESCRIPTION
## Description

This patch is not entirely complete and ready to merge, but I would like to begin reviewing it for reasons discussed below. All naming and organization should be up for discussion; I wasn't sure where we would want things so I have put them in a new file and given them 'strawman' names. Since we may want to change some or all of this, the usage documentation is not yet written; obviously that must be done before the review and merge complete. 

As a specific, more minor issue, the linter is not happy with `hop.robust_publisher.PublicationJournal._read_previous_journal`. The 
method is indeed fairly long, but most of my ideas for splitting it up would add more conceptual complexity, as state that currently exists shared within it would have to be shared among multiple methods. Suggestions would be welcome. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.