### PR TITLE
Add OAUTHBEARER/OIDC support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -271,6 +271,15 @@ auth = [{
          }]
 """
 
+# This is the OIDC configuration structure, which is very similar
+AUTH_CONFIG_OIDC = """
+auth = [{
+         username="username",
+         password="password",
+         token_endpoint="https://example.com/oauth2/token"
+         }]
+"""
+
 
 class MockBroker:
     """Mock a Kafka broker.
@@ -411,6 +420,11 @@ def legacy_auth_config():
 @pytest.fixture(scope="session")
 def auth_config():
     return AUTH_CONFIG
+
+
+@pytest.fixture(scope="session")
+def auth_config_oidc():
+    return AUTH_CONFIG_OIDC
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

Add OAUTHBEARER / OpenID Connect (OIDC) support as described in [KIP-768]. This is the authentication mechanism used by the GCN/TACH Kafka broker.

Depends on astronomy-commons/adc-streaming#53.

## Checklist

* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [ ] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
