### PR TITLE
Allow AvroBlob to take either a single record or a list of records

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,7 +243,7 @@ MESSAGE_AVRO = \
     b'\x2e\x33\x42\xea\xa7\x2a\xc4\x52'
 
 # Equivalent to the data encoded in MESSAGE_AVRO
-AVRO_DATA_EQUIVALENT = [{
+AVRO_DATA_EQUIVALENT = {
     "arr": [1, 2, 3, 4],
     "sub_objects": [{"a": 1, "b": 2}, {"c": 3, "d": 4}],
     "thingy": {
@@ -254,7 +254,7 @@ AVRO_DATA_EQUIVALENT = [{
     },
     "data": b"A\x00B\x04",
     "logic": [True, False],
-}]
+}
 
 # This was the original configuration structure, which permitted only a single credential
 AUTH_CONFIG_LEGACY = """\
@@ -486,6 +486,7 @@ def blob_msg():
     return {"content": MESSAGE_BLOB}
 
 
+# avro_data needs to be loaded with single_record=False here because
 message_parameters_dict_data = {
     # Generalize model_name, expected_model, test_file, and model_text
     # for easy access during tests. Useful when combined with parametrization

--- a/tests/data/expected_data/example_avro.stdout
+++ b/tests/data/expected_data/example_avro.stdout
@@ -1,1 +1,1 @@
-[{'arr': [1, 2, 3, 4], 'sub_objects': [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}], 'thingy': {'foo': 'abc', 'bar': 22, 'baz': None, 'quux': {'xen': b'def', 'hom': [89, 46, 5], 'drel': 2.718}}, 'data': b'A\x00B\x04', 'logic': [True, False]}]
+{'arr': [1, 2, 3, 4], 'sub_objects': [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}], 'thingy': {'foo': 'abc', 'bar': 22, 'baz': None, 'quux': {'xen': b'def', 'hom': [89, 46, 5], 'drel': 2.718}}, 'data': b'A\x00B\x04', 'logic': [True, False]}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,18 +99,34 @@ def test_avro(avro_data_raw, avro_data, avro_msg):
     serialized = avro.serialize()["content"]
     assert models.AvroBlob.load(serialized) == avro
 
-    # test that serializing the same object tree without a schema produces equivalent results
-    avro2 = models.AvroBlob(avro_data_raw)
+    # test single_record = False codepath
+    with patch("builtins.open", mock_open(read_data=avro_data)):
+        avro2 = models.AvroBlob.load(avro_data, single_record=False)
+
+    # verify data is correct after deserializing
+    assert avro2.content == [avro_data_raw]
+
+    # verify wrapper format is correct
+    assert avro2.serialize()["format"] == "avro"
+
+    # verify that serializing again produces the same result
     serialized2 = avro2.serialize()["content"]
+    assert models.AvroBlob.load(serialized2, single_record=False) == avro2
+
+    # test that serializing the same object tree without a schema produces equivalent results
+    avro3 = models.AvroBlob(avro_data_raw)
+    serialized3 = avro3.serialize()["content"]
+
     # serialized2 may not be the same as avro_data because the schemas can differ
-    assert models.AvroBlob.load(serialized2) == avro
+    assert models.AvroBlob.load(serialized3) == avro3
 
 
 def test_avro_invalid_data_type_serialization():
-    # data must be a sequence of records
+    # data must be a sequence of records if single_record = False
     with pytest.raises(TypeError) as te:
-        models.AvroBlob({1: "abc", False: "def"}).serialize()
-    assert "AvroBlob requires content to be a sequence of records" in str(te.value)
+        models.AvroBlob({1: "abc", False: "def"}, single_record=False).serialize()
+    assert "AvroBlob requires content to be a sequence of records when " \
+           "single_record = False" in str(te.value)
 
     # dictionary keys can only be strings
     with pytest.raises(ValueError) as ve:


### PR DESCRIPTION
## Description

I've had requests from consumers of streams that basically boil down to wanting the AvroBlob and JSONBlob objects to be capable of taking the same form of input, i.e. changing AvroBlob so that users can pass the same record to either message model and  can access the content from the deserialized message in the exact same way.

This PR accomplishes this by adding a new kwarg to several of the AvroBlob methods, `single_record`, which is True by default. If it is left as True, AvroBlob will expect a record not packed in a list everywhere, just like JSONBlob. If set to false, then AvroBlob can handle a list of an arbitrary number of records, like it does currently. I haven't updated the documentation yet because I wanted to make sure that this isn't a crazy idea.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [ ] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings. (this does produce warnings but they're not related to my changes as far as I can tell)
* [x] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.
                                                                                                                                                                                                                   
NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.   