### PR TITLE
Implement client-assigned message identifiers

### DIFF
--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -143,3 +143,26 @@ shown below:
     with stream.open("kafka://hostname:port/topic1", "r") as s:
         for message, metadata in s.read(metadata=True):
             print(message, metadata.headers)
+
+Standard Headers
+----------------
+
+The Hop client produces and uses certain message headers automatically. It is designed so that each
+header is intended to be optional, in the sense that messages lacking these headers can still be
+processed, but if a header is missing, functionality based on it may not be available. Headers
+currently automatically produced and used are:
+
+* :code:`_id`: The value of this header is a unique ID intended to allow referring to the specific
+  message without requiring context like its position within a Kafka topic. Message IDs are
+  currently generated as version 4 `RFC 4122 <https://datatracker.ietf.org/doc/html/rfc4122.html>`_
+  UUIDs. If the message ID header is missing, other users may not be able to send messages
+  which refer to the message, and systems which store messages may not be able to look it up
+  directly.
+* :code:`_test`: The presence of this header, with any value, should be interpreted to mean that the
+  message is a test, whose content may be safely ignored, or should otherwise not
+  necessarily be acted upon normally.
+* :code:`_format`: The value of this header is a UTF-8 string which is used to identify which
+  message model should be used to decode the message content. If the format header is missing,
+  an attempt will be made to decode the message content as JSON for backwards
+  compatibility with old client versions, and if it is not valid JSON the message content
+  will be left raw (treated as a `Blob`). 

--- a/hop/io.py
+++ b/hop/io.py
@@ -7,6 +7,7 @@ import logging
 import random
 import string
 from typing import List, Tuple, Union
+from uuid import uuid4
 import warnings
 
 import confluent_kafka
@@ -488,6 +489,8 @@ class Producer:
             headers = []
         elif isinstance(headers, Mapping):
             headers = list(headers.items())
+        # Assign a UUID to the message
+        headers.append(("_id", uuid4().bytes))
         if test:
             headers.append(('_test', b"true"))
         try:  # first try telling the message to serialize itself

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -8,6 +8,7 @@ import struct
 import time
 import threading
 from unittest.mock import patch, MagicMock
+from uuid import uuid4
 
 from adc.errors import KafkaException
 
@@ -809,8 +810,10 @@ def makeStream(*args, **kwargs):
 def test_rpublisher_empty_journal(tmpdir):
     journal_path = tmpdir.join("journal")
     url = "kafka://example.com/topic"
+    fixed_uuid = uuid4()
 
-    with patch("hop.io.Stream", makeStream()) as steam_middleman:
+    with patch("hop.io.Stream", makeStream()) as steam_middleman, \
+            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path) as pub:
             pub.write("a message")
 
@@ -855,8 +858,10 @@ def test_rpublisher_existing_journal(tmpdir):
 def test_rpublisher_immediate_send_fail(tmpdir):
     journal_path = tmpdir.join("journal")
     url = "kafka://example.com/topic"
+    fixed_uuid = uuid4()
 
-    with patch("hop.io.Stream", makeStream(immediate_failure=True)) as steam_middleman:
+    with patch("hop.io.Stream", makeStream(immediate_failure=True)) as steam_middleman, \
+            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path) as pub:
             pub.write("a message")
 
@@ -874,8 +879,10 @@ def test_rpublisher_poll_fail(tmpdir):
     print("test_rpublisher_poll_fail")
     journal_path = tmpdir.join("journal")
     url = "kafka://example.com/topic"
+    fixed_uuid = uuid4()
 
-    with patch("hop.io.Stream", makeStream(poll_failure=True)) as steam_middleman:
+    with patch("hop.io.Stream", makeStream(poll_failure=True)) as steam_middleman, \
+            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path) as pub:
             pub.write("a message")
 


### PR DESCRIPTION
## Description

This patch implements random UUID message identifiers. The producer attaches these to messages, but the consumer does not (and is not expected to) do anything with them, besides including them in the full set of message headers. 

## Checklist

~* [ ] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.
