### PR TITLE
Cli format cleanup

### DIFF
--- a/doc/user/commands.rst
+++ b/doc/user/commands.rst
@@ -41,13 +41,15 @@ This command allows a user to publish various structured and unstructured messag
 
 * `RFC 822 formatted GCN circular <https://gcn.gsfc.nasa.gov/gcn3_circulars.html>`_
 * An XML formatted `GCN/VOEvent notice <https://gcn.gsfc.nasa.gov/tech_describe.html>`_
-* Unstructured messages such as JSON-serializable data.
+* Unstructured messages such as JSON-serializable data,
+  `Apache Avro <https://avro.apache.org>`_-serializable data, or raw data bytes (blobs).
+
 
 Structured messages such as GCN circulars and VOEvents are published as JSON-formatted text.
 
 Unstructured messages may be piped to this command to be published. This mode of operation
-requires JSON input with individual messages separated by newlines, and the Blob format
-(`-f BLOB`) to be selected. 
+requires either the blob format (`-f BLOB`) or JSON (`-f JSON`) to be selected, and splits
+the input into separate messages at newlines.
 
 .. program-output:: hop publish --help
    :nostderr:

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import sys
 
@@ -46,16 +45,12 @@ def _main(args):
             message = loader.load_file(message_file)
             s.write(message)
 
-        # check if stdin is connected to TTY device
-        if not sys.stdin.isatty():
-            messages = sys.stdin.read().splitlines()
+        messages = sys.stdin.read().splitlines()
 
-            if messages:
-                assert args.format == io.Deserializer.BLOB.name, \
-                    "piping/redirection only allowed for BLOB formats"
+        if messages:
+            assert args.format == io.Deserializer.BLOB.name \
+                or args.format == io.Deserializer.JSON.name, \
+                "piping/redirection only allowed for BLOB and JSON formats"
 
-                try:
-                    for message in messages:
-                        s.write(loader.load(json.loads(message)), test=args.test)
-                except json.decoder.JSONDecodeError as err:
-                    raise ValueError("Blob messages must be valid JSON") from err
+            for message in messages:
+                s.write(loader.load(message), test=args.test)


### PR DESCRIPTION
## Description

After the major format refactoring, the CLI tool was continuing to accept only JSON when reading from standard input, while simultaneously enforcing that the `BLOB` format had to be requested. This was inconsistent and unhelpful. This patch separates the two formats, allowing either to be specified, and uses the standard `MessageModel.load` interface to interpet the message data (so JSON is parsed as such, and Blob data is left alone). 
Relax requirement that input may not be from a TTY.

## Checklist

* [ ] ~All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.
