### PR TITLE
Create Blob instead of crashing on binary data on deserialize

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -218,7 +218,7 @@ class _DeserializerMixin:
                 return from_format(old["content"], old["format"], deserialize=False)
             # not labeled according to our scheme, but it is valid JSON
             return models.JSONBlob(content=old)
-        except json.JSONDecodeError:  # if we can't tell what the data is, pass it on unchanged
+        except (UnicodeDecodeError, json.JSONDecodeError):  # if we can't tell what the data is, pass it on unchanged
             logger.warning("Unknown message format; returning a Blob")
             return models.Blob(content=message.value())
 

--- a/hop/io.py
+++ b/hop/io.py
@@ -218,7 +218,8 @@ class _DeserializerMixin:
                 return from_format(old["content"], old["format"], deserialize=False)
             # not labeled according to our scheme, but it is valid JSON
             return models.JSONBlob(content=old)
-        except (UnicodeDecodeError, json.JSONDecodeError):  # if we can't tell what the data is, pass it on unchanged
+        # if we can't tell what the data is, pass it on unchanged
+        except (UnicodeDecodeError, json.JSONDecodeError):
             logger.warning("Unknown message format; returning a Blob")
             return models.Blob(content=message.value())
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -79,7 +79,7 @@ def get_model_data(model_name):
         "content": make_message(b'{"format":"blob", "content":{"foo":"bar", "baz":5}}')},
     # messages produced by foreign clients which don't apply our format labels
     {"format": "json", "content": make_message(b'{"foo":"bar", "baz":5}')},
-    {"format": "blob", "content": make_message(b'some arbitrary data\0that hop can\'t read')},
+    {"format": "blob", "content": make_message(b'some arbitrary data\xDE\xAD\xBE\xEFthat hop can\'t read')},
 ])
 def test_deserialize(message, message_parameters_dict, caplog):
 


### PR DESCRIPTION
## Description

Currently, reading a message that has binary data without the proper deserialize plugin throws a UnicodeDecodeError exception.

I think the expected behavior is to create a Blob with the bytes.

This PR ignores any UnicodeDecodeErrors alongside JSONDecodeErrors

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [ ] `make lint` doesn't give any warnings.
* [ ] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
