### PR TITLE
Use pytest>=6.2.5 for Python 3.10 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     'dev': [
         'autopep8',
         'flake8',
-        'pytest >= 5.0, < 5.4',
+        'pytest >= 6.2.5',
         'pytest-console-scripts',
         'pytest-cov',
         'pytest-runner',


### PR DESCRIPTION
## Description

pytest was pinned at <= 5.3 in commit 8268ac0, though I'm not sure of the reason. pytest 6.2.5 and above appear to work properly, with all tests passing on python 3.6.1 and 3.9.15 on my machine.

pytest 6.2.5 fixed python 3.10 compatibility
https://docs.pytest.org/en/stable/changelog.html#pytest-6-2-5-2021-08-29

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [ ] `make lint` doesn't give any warnings.
* [ ] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
