### PR TITLE
Support IPv6 literal addresses and handle default ports sensibly

### DIFF
--- a/hop/auth.py
+++ b/hop/auth.py
@@ -276,7 +276,7 @@ def _decompose_host_port(hp):
     match = split_re.match(hp)
     if match is None:
         return ("", None)
-    return (match.group(1),match.group(3))
+    return (match.group(1), match.group(3))
 
 
 def select_matching_auth(creds, hostname, username=None):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ],
     },
 
-    python_requires = '>=3.6.*',
+    python_requires = '>=3.6',
     install_requires = install_requires,
     extras_require = extras_require,
     setup_requires = ['setuptools_scm'],

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
 extras_require = {
     'dev': [
         'autopep8',
-        'flake8',
+        'flake8 >= 3.3.0',
         'pytest >= 6.2.5',
         'pytest-console-scripts',
         'pytest-cov',

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -303,7 +303,7 @@ def test_prune_outdated_auth(tmpdir):
 
 
 def test_select_auth_inexact_host():
-    choices = [auth.Auth("user1", "pass1"), # no host
+    choices = [auth.Auth("user1", "pass1"),  # no host
                auth.Auth("user2", "pass2", host="some_host"),
                auth.Auth("user3", "pass3", host="other_host:9092")]
     # A credential with no host specified should match any host not exactly matched by any other
@@ -412,19 +412,19 @@ def test_select_auth_ambiguity():
 
 
 def test_select_auth_default_port():
-   choices = [auth.Auth("user", "pass", host="host"),
-              auth.Auth("user", "pass", host="other_host:9092")]
-   # A target with the default port explicitly specified should match a credential with the default
-   # port left implicit.
-   selected = auth.select_matching_auth(choices, "host:9092")
-   assert selected == choices[0]
+    choices = [auth.Auth("user", "pass", host="host"),
+               auth.Auth("user", "pass", host="other_host:9092")]
+    # A target with the default port explicitly specified should match a credential with the default
+    # port left implicit.
+    selected = auth.select_matching_auth(choices, "host:9092")
+    assert selected == choices[0]
 
-   choices = [auth.Auth("user", "pass", host="host:9092"),
-              auth.Auth("user", "pass", host="other_host")]
-   # A target with the port implicitly defaulted should match a credential with the default
-   # port left explicitly specified.
-   selected = auth.select_matching_auth(choices, "host")
-   assert selected == choices[0]
+    choices = [auth.Auth("user", "pass", host="host:9092"),
+               auth.Auth("user", "pass", host="other_host")]
+    # A target with the port implicitly defaulted should match a credential with the default
+    # port left explicitly specified.
+    selected = auth.select_matching_auth(choices, "host")
+    assert selected == choices[0]
 
 
 def test_auth_location_fallback(tmpdir):


### PR DESCRIPTION
## Description

- Hostname URI checks were overly strict previously, and would reject literal IPv6 addresses for containing colons. 
- URIs with a default port explicitly specified were not matched against it being left implicit, or vice-versa, which defeated much of the purpose of allowing the port specification to be optional.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
~* [ ] Add/update sphinx documentation with any relevant changes.~
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
