### PR TITLE
Expose ability to commit offsets synchronously

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -364,6 +364,8 @@ class Consumer:
 
         Args:
             metadata: A Metadata instance containing broker-specific metadata.
+            asynchronous: Whether to allow the commit to happen asynchronously
+                          in the background.
 
         """
         self._consumer.mark_done(metadata._raw, asynchronous)

--- a/hop/io.py
+++ b/hop/io.py
@@ -359,14 +359,14 @@ class Consumer:
         else:
             return payload
 
-    def mark_done(self, metadata):
+    def mark_done(self, metadata, asynchronous: bool = True):
         """Mark a message as fully-processed.
 
         Args:
             metadata: A Metadata instance containing broker-specific metadata.
 
         """
-        self._consumer.mark_done(metadata._raw)
+        self._consumer.mark_done(metadata._raw, asynchronous)
 
     def close(self):
         """End all subscriptions and shut down.


### PR DESCRIPTION
## Description

This change just exposes the existing functionality in librdkafka/adc-streaming to commit consumer group offsets sychronously, rather than the default of asynchronous commit. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
~* [ ] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.~
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
