### PR TITLE
Fix authentication procedure in RobustPublisher

### DIFF
--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -803,7 +803,7 @@ class FakeProducer:
 # build pointless layers surrounding the hop.io.Producer class
 def makeStream(auth=None, *args, **kwargs):
     opener = MagicMock()
-    opener.auth = None if auth is None else auth
+    opener.auth = auth or None
     opener.open = MagicMock(return_value=FakeProducer(*args, **kwargs))
     return MagicMock(return_value=opener)
 


### PR DESCRIPTION
## Description

RobustPublisher currently does not work at all because it's using an older auth API. It isn't caught in the tests because `Stream` gets mocked like the old format. This PR fixes it using the credential selection code from `Stream.open`.

## Checklist

* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [ ] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

