### PR TITLE
Expose stop method for Consumer

### DIFF
--- a/hop/io.py
+++ b/hop/io.py
@@ -401,6 +401,12 @@ class Consumer:
         """
         self._consumer.mark_done(metadata._raw, asynchronous)
 
+    def stop(self):
+        """Stops the runloop of the consumer. Useful when running the
+        consumer in a different thread.
+        """
+        self._consumer.stop()
+
     def close(self):
         """End all subscriptions and shut down.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 2.1.0",
+    "adc-streaming >= 2.2.0",
     "dataclasses ; python_version < '3.7'",
     "fastavro >= 1.4.0",
     "pluggy >= 0.11",


### PR DESCRIPTION
## Description

Exposes the stop method for the underlying adc-streaming Consumer class.

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
