### PR TITLE
Expose the capability to multiple topics

### DIFF
--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -82,13 +82,32 @@ Kafka topics, and takes the form:
 
 .. code:: bash
 
-   kafka://[username@]broker/topic[,topic2[,...]]
+   kafka://[username@]broker/[topic[,topic2[,...]]]
 
 The broker takes the form :code:`hostname[:port]` and gives the URL to connect to a
 Kafka broker. Optionally, a :code:`username` can be provided, which is used to select 
 among available credentials to use when communicating with the broker. 
-Finally, one can publish to a topic or subscribe to one or more topics to consume messages
-from.
+Finally, one can specify a number of topics to which to publish or subscribe.
+
+Publishing to Multiple Topics
+-------------------------------
+
+A single stream object can be used to publish to multiple topics, and doing so uses resources
+more efficiently by spawning fewer worker threads, opening fewer sockets, etc., than opening a
+separate stream for each of several topics, but requires attention to one extra detail: When a
+stream is opened for multiple topics, the topic must be specified when calling :code:`write()`,
+in order to make unambiguous to which topic that particular message should be published:
+
+.. code:: python
+
+    from hop import stream
+
+    with stream.open("kafka://hostname:port/topic1,topic2", "w") as s:
+        s.write({"my": "message"}, topic="topic2")
+
+In fact, when opening a stream for writing, it is not necessary for the target URL to contain
+a topic at all; if it does not, the topic to which to publish must always be specified when
+calling :code:`write()`.
 
 Committing Messages Manually
 ------------------------------

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 2.2.0",
+    "adc-streaming >= 2.4.0",
     "dataclasses ; python_version < '3.7'",
     "fastavro >= 1.4.0",
     "pluggy >= 0.11",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,8 +367,13 @@ def mock_producer():
                 self.broker = broker
                 self.topic = topic
 
-            def write(self, msg, headers=[], delivery_callback=None):
-                self.broker.write(self.topic, msg, headers)
+            def write(self, msg, headers=[], delivery_callback=None, topic=None):
+                if topic is None:
+                    if self.topic is not None:
+                        topic = self.topic
+                    else:
+                        raise Exception("No topic specified for write")
+                self.broker.write(topic, msg, headers)
 
             def close(self):
                 pass


### PR DESCRIPTION
## Description

Based on https://github.com/astronomy-commons/adc-streaming/pull/69 , this exposes the same functionality through the hop API. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.