### PR TITLE
Implement Large Message Offloading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ User's Guide
    user/auth
    user/models
    user/robust_publication
+   user/large_messages
    user/commands
 
 API Reference

--- a/doc/user/commands.rst
+++ b/doc/user/commands.rst
@@ -12,6 +12,7 @@ Commands
 * :code:`hop list-topics`: SHow accessible Kafka topics
 * :code:`hop publish`: Publish messages such as GCN circulars and notices
 * :code:`hop subscribe`: Listen to messages such as GCN circulars and notices
+* :code:`hop configure`: Subcommands for checking and setting configuration options
 * :code:`hop version`: Show version dependencies of :code:`hop-client`
 
 :code:`hop auth`
@@ -61,6 +62,37 @@ the input into separate messages at newlines.
 This command allows a user to subscribe to messages and print them to stdout.
 
 .. program-output:: hop subscribe --help
+   :nostderr:
+
+:code:`hop configure`
+~~~~~~~~~~~~~~~~~~~~~~
+
+This is a category of subcommands which allow a user to check and set configuration options for
+:code:`hop-client`, both as a command-line tool and a library.
+
+:code:`hop configure locate`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command provides information on the location(s) from which configuration data will be read.
+
+.. program-output:: hop configure locate --help
+   :nostderr:
+
+:code:`hop configure show`
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command outputs the current configuration including both data from configuration files and any
+overriding values specified via environment variables. 
+
+.. program-output:: hop configure show --help
+   :nostderr:
+
+:code:`hop configure set`
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command records a new value for a configuration parameter to the configuration file.
+
+.. program-output:: hop configure set --help
    :nostderr:
 
 :code:`hop version`

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -3,6 +3,7 @@ import logging
 import os
 import toml
 from typing import Optional
+import warnings
 
 from . import cli
 
@@ -102,10 +103,16 @@ def load_config(config_path: Optional[str] = None):
         config_path = get_config_path("general")
     if os.path.exists(config_path):
         try:
-            with open(config_path, 'r') as file:
-                config = Config.load(file)
-        except Exception as ex:
-            raise RuntimeError(f"Error loading {config_path}") from ex
+            file = open(config_path, 'r')
+        except Exception:
+            warnings.warn(f"Unable to open {config_path} for reading; using default configuration")
+            config = Config()
+        else:
+            try:
+                with file:
+                    config = Config.load(file)
+            except Exception as ex:
+                raise RuntimeError(f"Error loading {config_path}") from ex
     else:
         config = Config()
 

--- a/hop/configure.py
+++ b/hop/configure.py
@@ -1,5 +1,8 @@
+import dataclasses
 import logging
 import os
+import toml
+from typing import Optional
 
 from . import cli
 
@@ -37,6 +40,130 @@ def get_config_path(type: str = "general"):
         return os.path.join(os.getenv("HOME"), ".config", auth_filepath)
 
 
+@dataclasses.dataclass
+class Config:
+    """A container class for general configuration parameters
+    """
+    fetch_external: bool = True
+    automatic_offload: bool = True
+
+    def asdict(self):
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def load(cls, input):
+        if hasattr(input, "read"):
+            input = input.read()
+        try:
+            return cls(**toml.loads(input)["config"])
+        except KeyError:
+            raise RuntimeError("configuration data has no config section") from None
+        except Exception as ex:
+            raise RuntimeError(f"configuration data is malformed: {ex}")
+
+    def save(self, output):
+        toml.dump({"config": self.asdict()}, output)
+
+
+def _parse_bool(s: str):
+    """Interpret a range of possible truthy string values as booleans
+    """
+    s = s.lower()
+    if s == "true" or s == "yes" or s == "on" or s == "1":
+        return True
+    if s == "false" or s == "no" or s == "off" or s == "0":
+        return False
+    raise ValueError(f"Invalid boolean value '{s}'")
+
+
+# The mapping of types to functions used for parsing strings provided by the user into configuration
+# values. When no entry for a given type exists in this object, the type's normal constructor should
+# be used.
+_conversion_functions = {
+    bool: _parse_bool
+}
+
+
+def load_config(config_path: Optional[str] = None):
+    """
+    Load the configuration settings for the library combining, in order of increasing precedence:
+    1. The built-in defaults
+    2. Defaults stored in the configuration file
+    3. Values currently set in the environment as environment variables
+
+    Args:
+        config_path: The path to the configuration file to load. If unspecified, the default
+                     location is used.
+    Return: A Config object with all current settings
+    """
+    # First, load the specified file, or the default file if not specified
+    # If the file does not exist, use built-in defaults
+    if config_path is None:
+        config_path = get_config_path("general")
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, 'r') as file:
+                config = Config.load(file)
+        except Exception as ex:
+            raise RuntimeError(f"Error loading {config_path}") from ex
+    else:
+        config = Config()
+
+    # Second, check for any environment variables and apply them if found
+    env_var_prefix = "HOP_"
+
+    for field in dataclasses.fields(config):
+        var_name = (env_var_prefix + field.name).upper()
+        value = os.getenv(var_name)
+        if value is None:
+            continue
+        try:
+            if field.type in _conversion_functions:
+                value = _conversion_functions[field.type](value)
+            else:
+                value = field.type(value)
+        except Exception as ex:
+            raise RuntimeError(f"Error parsing configuration variable {var_name}") from ex
+        setattr(config, field.name, value)
+
+    return config
+
+
+def write_config_value(name: str, value):
+    """
+    Store a configuration value to the configuation file.
+
+    Args:
+        name: The name of the parameter to store. Must be a valid parameter name.
+        value: The parameter value to store. Must be the correct type for the specified parameter.
+    """
+    config_path = get_config_path("general")
+
+    # Load any existing configuration
+    # We do not use load_config because we want to avoid baking in any temporary settings
+    # provided in environment variables, or any built-in defaults not explicitly chosen by the
+    # user.
+    if os.path.exists(config_path):
+        try:
+            config = toml.load(config_path)["config"]
+        except KeyError:
+            raise RuntimeError("{config_path} has no config section") from None
+        except Exception as ex:
+            raise RuntimeError(f"{config_path} is malformed: {ex}")
+    else:
+        config = {}
+
+    # Set/overwrite the parameter specified by the user
+    config[name] = value
+
+    # Write the resulting configuration back out
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, 'w') as output:
+        toml.dump({"config": config}, output)
+
+    logger.info(f"Wrote {name} = {value} to {config_path}")
+
+
 def _add_parser_args(parser):
     cli.add_logging_opts(parser)
 
@@ -49,6 +176,15 @@ def _add_parser_args(parser):
                                help="The type of configuration file to locate. "
                                "Defaults to general configuration.")
 
+    subparser.add_parser("show", help="display current configuration")
+
+    set_parser = subparser.add_parser("set", help="set default value for a configuration parameter")
+    set_parser.add_argument("name",
+                            choices=[field.name for field in dataclasses.fields(Config)],
+                            help="The configuration parameter to set")
+    set_parser.add_argument("value",
+                            help="The parameter value to set")
+
 
 def _main(args):
     """Configuration utilities.
@@ -58,3 +194,22 @@ def _main(args):
 
     if args.command == "locate":
         print(get_config_path(args.type))
+    elif args.command == "show":
+        config = load_config()
+        for field in dataclasses.fields(config):
+            print(f"{field.name}: {getattr(config, field.name)}")
+    elif args.command == "set":
+        # Collect data supplied by the user
+        name = args.name
+        # the argument parser should enforce that name is a value configuration parameter
+        for field in dataclasses.fields(Config):
+            if field.name == name:
+                break
+        value = args.value
+        # sanitize/normalize the provided value
+        if field.type in _conversion_functions:
+            value = _conversion_functions[field.type](value)
+        else:
+            value = field.type(value)
+
+        write_config_value(name, value)

--- a/hop/http_scram.py
+++ b/hop/http_scram.py
@@ -92,11 +92,9 @@ class SCRAMAuth(requests.auth.AuthBase):
         # Next, make sure that both of the fields we need were actually sent in the dictionary
         if auth_data.get("sid", None) is None:
             self._thread_local.num_calls = 0
-            return r
             raise RuntimeError("Missing sid in SCRAM server first: " + m.group(1))
         if auth_data.get("data", None) is None:
             self._thread_local.num_calls = 0
-            return r
             raise RuntimeError("Missing data in SCRAM server first: " + m.group(1))
 
         self._thread_local.sid = auth_data.get("sid")

--- a/hop/http_scram.py
+++ b/hop/http_scram.py
@@ -1,0 +1,166 @@
+import base64
+import logging
+import re
+import requests
+from scramp import ScramClient
+import secrets
+import threading
+
+
+logger = logging.getLogger("hop")
+
+
+class SCRAMAuth(requests.auth.AuthBase):
+    def __init__(self, credential, shortcut: bool = False, check_final=True):
+        self._thread_local = threading.local()
+        # these are immutable, so we do not bother making them thread-local
+        self.username = credential.username
+        self.password = credential.password
+        self.mechanism = credential.mechanism.upper()
+        self.shortcut = shortcut
+        self.check_final = check_final
+
+    def init_per_thread_state(self):
+        if not hasattr(self._thread_local, "init"):
+            self._thread_local.init = True
+            self._thread_local.num_calls = 0
+            self._thread_local.saved_body = None
+
+    def _redo_request(self, r: requests.Response, auth_header: str, final: bool = False, **kwargs):
+        # Consume content and release the original connection
+        # to allow our new request to reuse the same one.
+        r.content
+        r.close()
+        prep = r.request.copy()
+        requests.cookies.extract_cookies_to_jar(prep._cookies, r.request, r.raw)
+        prep.prepare_cookies(prep._cookies)
+        if final and self.shortcut and self._thread_local.saved_body is not None:
+            prep.prepare_body(self._thread_local.saved_body, None)
+
+        prep.headers['Authorization'] = auth_header
+        prep.register_hook("response", self.process)
+        _r = r.connection.send(prep, **kwargs)
+        _r.history.append(r)
+        _r.request = prep
+        return _r
+
+    def _generate_client_first(self):
+        """Perform the client-side preparation for the first round of the SCRAM exchange.
+
+            Returns: The encoded data for the Authorization header
+        """
+        self._thread_local.nonce = secrets.token_urlsafe()
+        logger.debug(f" client nonce: {self._thread_local.nonce}")
+        self._thread_local.sclient = ScramClient([self.mechanism],
+                                                 self.username, self.password,
+                                                 c_nonce=self._thread_local.nonce)
+        cfirst = self._thread_local.sclient.get_client_first()
+        logger.debug(f" client first: {cfirst}")
+        cfirst = cfirst.encode("utf-8")
+        return f"{self.mechanism} data={base64.b64encode(cfirst).decode('utf-8')}"
+
+    def _handle_first(self, r: requests.Response, **kwargs):
+        # Need to examine which auth mechanisms the server declares it accepts to find out
+        # if the one we can do is on the list
+        mechanisms = requests.utils.parse_list_header(r.headers.get("www-authenticate", ""))
+        matching_mech = False
+        for mechanism in mechanisms:
+            if mechanism.upper() == self.mechanism or \
+                    mechanism.upper().startswith(self.mechanism + " "):
+                matching_mech = True
+                break
+        if not matching_mech:
+            self._thread_local.num_calls = 0
+            return r
+        # At this point we know our mechanism is allowed, so we begin the SCRAM exchange
+
+        self._thread_local.num_calls = 1
+        return self._redo_request(r, auth_header=self._generate_client_first(), **kwargs)
+
+    def _handle_final(self, r: requests.Response, **kwargs):
+        # To contiue the handshake, the server should have set the www-authenticate header to
+        # the mechanism we are using, followed by the data we need to use.
+        # Check for this, and isolate the data to parse.
+        logger.debug(f"Authenticate header sent by server: {r.headers.get('www-authenticate')}")
+        m = re.fullmatch(f"{self.mechanism} (.+)", r.headers.get("www-authenticate"),
+                         flags=re.IGNORECASE)
+        if not m:
+            self._thread_local.num_calls = 0
+            return r
+        auth_data = requests.utils.parse_dict_header(m.group(1))
+        logger.debug("auth_data:", auth_data)
+        # Next, make sure that both of the fields we need were actually sent in the dictionary
+        if auth_data.get("sid", None) is None:
+            self._thread_local.num_calls = 0
+            return r
+            raise RuntimeError("Missing sid in SCRAM server first: " + m.group(1))
+        if auth_data.get("data", None) is None:
+            self._thread_local.num_calls = 0
+            return r
+            raise RuntimeError("Missing data in SCRAM server first: " + m.group(1))
+
+        self._thread_local.sid = auth_data.get("sid")
+        sfirst = auth_data.get("data")
+        logger.debug(f" sid: {self._thread_local.sid}")
+        sfirst = base64.b64decode(sfirst).decode("utf-8")
+        logger.debug(f" server first: {sfirst}")
+        self._thread_local.sclient.set_server_first(sfirst)
+        cfinal = self._thread_local.sclient.get_client_final()
+        logger.debug(f" client final: {cfinal}")
+        cfinal = base64.b64encode(cfinal.encode("utf-8")).decode('utf-8')
+        self._thread_local.num_calls = 2
+        return self._redo_request(r, auth_header=f"{self.mechanism} "
+                                  f"sid={self._thread_local.sid},data={cfinal}", final=True)
+
+    def _check_server_final(self, r: requests.Response, **kwargs):
+        # The standard says that we MUST authenticate the server by checking the
+        # ServerSignature, and treat it as an error if they do not match.
+        logger.debug(f" authentication-info: {r.headers.get('authentication-info', None)}")
+        raw_auth_data = r.headers.get("authentication-info", "")
+        auth_data = requests.utils.parse_dict_header(raw_auth_data)
+        # Next, make sure that both of the fields we need were actually sent in the dictionary
+        if auth_data.get("sid", None) is None:
+            self._thread_local.num_calls = 0
+            raise RuntimeError("Missing sid in SCRAM server final: " + raw_auth_data)
+        if auth_data.get("data", None) is None:
+            self._thread_local.num_calls = 0
+            raise RuntimeError("Missing data in SCRAM server final: " + raw_auth_data)
+        if auth_data.get("sid") != self._thread_local.sid:
+            self._thread_local.num_calls = 0
+            raise RuntimeError("sid mismatch in server final www-authenticate header")
+        sfinal = auth_data.get("data")
+        self._thread_local.sclient.set_server_final(base64.b64decode(sfinal).decode("utf-8"))
+
+    def process(self, r: requests.Response, **kwargs):
+        if self._thread_local.num_calls < 2 and "www-authenticate" not in r.headers:
+            self._thread_local.num_calls = 0
+            return r
+        if self._thread_local.num_calls >= 2:
+            self._check_server_final(r)
+            # prevent infinite looping if something goes wrong
+            r.request.deregister_hook("response", self.process)
+
+        if r.status_code == 401:
+            if self._thread_local.num_calls == 0:
+                return self._handle_first(r, **kwargs)
+            elif self._thread_local.num_calls == 1:
+                return self._handle_final(r, **kwargs)
+        return r
+
+    def __call__(self, r):
+        self.init_per_thread_state()
+
+        r.register_hook("response", self.process)
+        # This is a bit hacky and not fully general:
+        # If we are using the shortcut of assuming that we must do SCRAM authentication,
+        # we assume that the request will have to be repeated, so we remove the body initially and
+        # squirrel it away to be re-attached to the final request at the end of the SCRAM handshake.
+        # This has the advantage of not sending the potentially large body data repeatedly.
+        if self.shortcut:
+            self._thread_local.saved_body = r.body
+            r.prepare_body(b"", None)
+            r.headers["Content-Length"] = 0
+            r.headers['Authorization'] = self._generate_client_first()
+            self._thread_local.num_calls = 1  # skip state ahead
+
+        return r

--- a/hop/http_scram.py
+++ b/hop/http_scram.py
@@ -12,6 +12,18 @@ logger = logging.getLogger("hop")
 
 class SCRAMAuth(requests.auth.AuthBase):
     def __init__(self, credential, shortcut: bool = False, check_final=True):
+        """
+        Args:
+            credential: The set of SCRAM credentials to supply when connecting
+            shortcut: Do not wait for a challenge from the server, and skip directly to sending the
+                      authentication 'response', which in this case is the SCRAM
+                      'client-first-message'. This saves a pointless network round-trip when
+                      authentication is needed and the client can be certain that this is the
+                      necessary scheme.
+            check_final: Perform the final check of the server signature required by RFC 5802. The
+                         value of this is unclear when communication is over HTTPS and the server
+                         has already been authenticated by the TLS.
+        """
         self._thread_local = threading.local()
         # these are immutable, so we do not bother making them thread-local
         self.username = credential.username

--- a/hop/io.py
+++ b/hop/io.py
@@ -922,6 +922,7 @@ class Producer:
                 is either delivered or permanently fails to be delivered.
             topic: The topic to which the message should be sent. This need not be specified if
                    the stream was opened with a URL containing exactly one topic name.
+            key: If specified, the Kafka message key
         """
         if topic is None and self.default_topic is not None:
             topic = self.default_topic

--- a/hop/io.py
+++ b/hop/io.py
@@ -930,7 +930,7 @@ class Producer:
                             "Either configure a topic when opening the Stream, "
                             "or specify the topic argument to write()")
         if delivery_callback is None:
-            delivery_callback = lambda *args: None
+            delivery_callback = lambda *args: None  # noqa: E731
 
         estimated_size = self._estimate_message_size(packed_message, headers)
         t_record = self._record_for_topic(topic)

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -45,12 +45,13 @@ def _main(args):
             message = loader.load_file(message_file)
             s.write(message)
 
-        messages = sys.stdin.read().splitlines()
+        if len(args.message) == 0:
+            messages = sys.stdin.read().splitlines()
 
-        if messages:
-            assert args.format == io.Deserializer.BLOB.name \
-                or args.format == io.Deserializer.JSON.name, \
-                "piping/redirection only allowed for BLOB and JSON formats"
+            if messages:
+                assert args.format == io.Deserializer.BLOB.name \
+                    or args.format == io.Deserializer.JSON.name, \
+                    "piping/redirection only allowed for BLOB and JSON formats"
 
-            for message in messages:
-                s.write(loader.load(message), test=args.test)
+                for message in messages:
+                    s.write(loader.load(message), test=args.test)

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -5,6 +5,7 @@ import os
 import struct
 import time
 import threading
+from typing import Union
 import zlib
 
 from . import io
@@ -181,7 +182,8 @@ class PublicationJournal:
             raise RuntimeError(f"Failed to append record to journal: {e}")
 
     # returns the sequence number assigned to the message
-    def queue_message(self, message: bytes, topic: str, headers=None, key: bytes | str = None):
+    def queue_message(self, message: bytes, topic: str, headers=None,
+                      key: Union[bytes, str] = None):
         """Record to the journal a message which is to be sent.
 
         Args:

--- a/hop/robust_publisher.py
+++ b/hop/robust_publisher.py
@@ -861,10 +861,17 @@ class RobustProducer(threading.Thread):
         Args:
             message: A message to send.
             headers: Headers to be sent with the message, as a list of 2-tuples of strings.
+            test: The message should be marked as a test message by adding a header with
+                  key '_test'.
+            topic: The topic to which the message should be sent. This need not be specified if the
+                   producer was constructed with a URL containing exactly one topic name.
+            key: If specified, the Kafka message key
 
         Raises:
             RuntimeError: If appending the new message to the on-disk journal fails.
             TypeError: If the message is not a suitable type.
+            Exception: If a single topic was not specified in the original URL and the topic
+                       argument was not set.
 
         """
         if topic is None and self._stream.default_topic is not None:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ install_requires = [
     "fastavro >= 1.4.0",
     "pluggy >= 0.11",
     "toml >= 0.9.4",
-    "xmltodict >= 0.9.0"
+    "xmltodict >= 0.9.0",
+    "scramp",
+    "bson",
 ]
 extras_require = {
     'dev': [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_dir, 'README.md'), 'rb') as f:
 
 # requirements
 install_requires = [
-    "adc-streaming >= 2.4.0",
+    "adc-streaming >= 2.5.0",
     "dataclasses ; python_version < '3.7'",
     "fastavro >= 1.4.0",
     "pluggy >= 0.11",

--- a/tests/data/expected_data/example_blob.stdout
+++ b/tests/data/expected_data/example_blob.stdout
@@ -1,1 +1,1 @@
-This is a sample blob message. It is unstructured and does not require special parsing.
+b'This is a sample blob message. It is unstructured and does not require special parsing.'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_publish(script_runner, message_format, message_parameters_dict):
         assert ret.stderr == ""
 
         # verify message was processed
-        if message_format == "voevent":
+        if message_format in ["voevent", "blob"]:
             mock_file.assert_called_with(test_file, "rb")
         else:
             mock_file.assert_called_with(test_file, "r")
@@ -95,6 +95,8 @@ def test_cli_publish_blob_msgs(mock_broker, mock_producer, mock_consumer):
     start_at = io.StartPosition.EARLIEST
     read_url = "kafka://group@hostname:port/topic"
     fixed_uuid = uuid4()
+    fake_uuid = MagicMock()
+    fake_uuid.uuid4 = MagicMock(return_value=fixed_uuid)
 
     mock_adc_producer = mock_producer(mock_broker, "topic")
     mock_adc_consumer = mock_consumer(mock_broker, "topic", "group")
@@ -103,7 +105,7 @@ def test_cli_publish_blob_msgs(mock_broker, mock_producer, mock_consumer):
         with patch("sys.stdin", BytesIO(msg)) as mock_stdin, \
                 patch("hop.io.producer.Producer", return_value=mock_adc_producer), \
                 patch("hop.io.consumer.Consumer", return_value=mock_adc_consumer), \
-                patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+                patch("hop.io.uuid", fake_uuid):
             publish._main(args)
 
             # each published message should be on the broker
@@ -136,6 +138,8 @@ def test_cli_publish_json_blob_msgs(mock_broker, mock_producer, mock_consumer):
     start_at = io.StartPosition.EARLIEST
     read_url = "kafka://group@hostname:port/topic"
     fixed_uuid = uuid4()
+    fake_uuid = MagicMock()
+    fake_uuid.uuid4 = MagicMock(return_value=fixed_uuid)
 
     mock_adc_producer = mock_producer(mock_broker, "topic")
     mock_adc_consumer = mock_consumer(mock_broker, "topic", "group")
@@ -145,7 +149,7 @@ def test_cli_publish_json_blob_msgs(mock_broker, mock_producer, mock_consumer):
         with patch("sys.stdin", StringIO(json.dumps(msg))) as mock_stdin, \
                 patch("hop.io.producer.Producer", return_value=mock_adc_producer), \
                 patch("hop.io.consumer.Consumer", return_value=mock_adc_consumer), \
-                patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+                patch("hop.io.uuid", fake_uuid):
             publish._main(args)
 
             # each published message should be on the broker

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,6 +1,10 @@
+import dataclasses
+from io import StringIO
 import pytest
+import toml
 import os
-from conftest import temp_environ
+from unittest.mock import patch
+from conftest import temp_config, temp_environ
 
 from hop import configure
 
@@ -48,10 +52,174 @@ def test_get_config_path_invalid(tmpdir):
         configure.get_config_path("hairstyle")
 
 
+def test_Config_load():
+    # can load from a string
+    c1 = configure.Config.load(StringIO("[config]"))
+    for field in dataclasses.fields(configure.Config):
+        assert getattr(c1, field.name) == field.default, \
+            "default values should be used when not specified"
+
+    non_default = StringIO()
+    non_default.write("[config]\n")
+    for field in dataclasses.fields(configure.Config):
+        if field.type is bool:
+            non_default.write(f"{field.name} = {str(not field.default).lower()}\n")
+    c2 = configure.Config.load(non_default.getvalue())
+    for field in dataclasses.fields(configure.Config):
+        if field.type is bool:
+            assert getattr(c2, field.name) != field.default, \
+                "non-default values should be read correctly"
+        else:
+            assert getattr(c2, field.name) == field.default, \
+                "default values should be used when not specified"
+
+    with pytest.raises(RuntimeError) as ex:
+        configure.Config.load("valid = false\n")
+    assert "configuration data has no config section" in str(ex)
+
+    with pytest.raises(RuntimeError) as ex:
+        configure.Config.load('{"this": "is not TOML", "json": "yes"}')
+    assert "configuration data is malformed" in str(ex)
+
+
+def test_Config_roundtrip():
+    out_buf = StringIO()
+    c1 = configure.Config()
+    # set some non-default values
+    for field in dataclasses.fields(configure.Config):
+        if field.type is bool:
+            setattr(c1, field.name, not field.default)
+    c1.save(out_buf)
+    in_buf = StringIO(out_buf.getvalue())
+    c2 = configure.Config.load(in_buf)
+    assert c1 == c2
+
+
+def test_parse_bool():
+    assert configure._parse_bool("TrUe")
+    assert configure._parse_bool("Yes")
+    assert configure._parse_bool("oN")
+    assert configure._parse_bool("1")
+    assert not configure._parse_bool("fAlsE")
+    assert not configure._parse_bool("No")
+    assert not configure._parse_bool("oFF")
+    assert not configure._parse_bool("0")
+    with pytest.raises(ValueError) as ex:
+        configure._parse_bool("fish")
+    assert "Invalid boolean value" in str(ex)
+    assert "fish" in str(ex)
+
+
+def test_load_config(general_config, tmpdir):
+    with temp_config(tmpdir, general_config) as conf_dir, temp_environ(XDG_CONFIG_HOME=conf_dir):
+        config = configure.load_config()
+        assert not config.fetch_external
+        assert not config.automatic_offload
+
+    # if there is no file, we should construct a default object
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+        config = configure.load_config()
+        assert config == configure.Config()
+
+    # when specified, we should load from a non-default path
+    with temp_config(tmpdir, general_config) as conf_dir, temp_environ(XDG_CONFIG_HOME=conf_dir):
+        alt_path = f"{tmpdir}/other.toml"
+        with open(alt_path, 'w') as f:
+            toml.dump({"config": {"fetch_external": not configure.Config.fetch_external}}, f)
+        config = configure.load_config(alt_path)
+        os.remove(alt_path)
+        assert not config.fetch_external
+        assert config.automatic_offload
+
+    # malformed data should cause a meaningful error
+    with temp_config(tmpdir, "BAD\tTOML") as conf_dir, temp_environ(XDG_CONFIG_HOME=conf_dir):
+        with pytest.raises(RuntimeError) as ex:
+            config = configure.load_config()
+        assert f"Error loading {conf_dir}" in str(ex)
+
+
+def test_load_config_env(tmpdir):
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir), HOP_FETCH_EXTERNAL="no"):
+        config = configure.load_config()
+        assert not config.fetch_external
+        assert config.automatic_offload
+
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir), HOP_FETCH_EXTERNAL="elk"):
+        with pytest.raises(RuntimeError) as ex:
+            config = configure.load_config()
+        assert "Error parsing configuration variable HOP_FETCH_EXTERNAL" in str(ex)
+        assert ex.value.__cause__ is not None
+        assert "Invalid boolean value" in str(ex.value.__cause__)
+
+    @dataclasses.dataclass
+    class FakeConfig:
+        number: int = 2
+
+    with patch("hop.configure.Config", FakeConfig):
+        with temp_environ(XDG_CONFIG_HOME=str(tmpdir), HOP_NUMBER="8"):
+            config = configure.load_config()
+            assert config.number == 8
+
+        with temp_environ(XDG_CONFIG_HOME=str(tmpdir), HOP_NUMBER="rhino"):
+            with pytest.raises(RuntimeError) as ex:
+                config = configure.load_config()
+            assert "Error parsing configuration variable HOP_NUMBER" in str(ex)
+            assert ex.value.__cause__ is not None
+            assert "invalid literal for int() with base 10: 'rhino'" in str(ex.value.__cause__)
+
+
+def test_write_config_value(general_config, tmpdir):
+    os.makedirs(f"{tmpdir}/hop", exist_ok=True)
+
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+        value = not configure.Config.fetch_external
+        configure.write_config_value("fetch_external", value)
+        config_path = configure.get_config_path("general")
+        assert os.path.exists(config_path)
+        with open(config_path, 'r') as f:
+            data = toml.load(f)
+        os.remove(config_path)
+        assert "config" in data
+        assert "fetch_external" in data["config"]
+        assert data["config"]["fetch_external"] == value
+
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir), HOP_AUTOMATIC_OFFLOAD="0"):
+        value = not configure.Config.fetch_external
+        configure.write_config_value("fetch_external", value)
+        config_path = configure.get_config_path("general")
+        assert os.path.exists(config_path)
+        with open(config_path, 'r') as f:
+            data = toml.load(f)
+        os.remove(config_path)
+        assert "config" in data
+        assert "fetch_external" in data["config"]
+        assert "automatic_offload" not in data["config"], "environment variables must be ignored"
+
+    # Valid TOML with the wrong data should yield an error
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+        config_path = configure.get_config_path("general")
+        with open(config_path, 'w') as f:
+            toml.dump({"not-config": 17}, f)
+        with open(config_path, 'r') as f:
+            data = f.read()
+        print(data)
+        with pytest.raises(RuntimeError) as ex:
+            configure.write_config_value("fetch_external", True)
+        assert "has no config section" in str(ex)
+
+    with temp_environ(XDG_CONFIG_HOME=str(tmpdir)):
+        config_path = configure.get_config_path("general")
+        with open(config_path, 'w') as f:
+            f.write('{"this": "is not TOML", "json": "yes"}')
+        with pytest.raises(RuntimeError) as ex:
+            configure.write_config_value("fetch_external", True)
+        assert "is malformed" in str(ex)
+
+
 def test_no_command_configure(script_runner):
     warning_message = (
         "hop configure: error: the following arguments are required: <command>"
     )
-    ret = script_runner.run("hop", "configure")
+    ret = script_runner.run(["hop", "configure"])
     assert not ret.success
     assert warning_message in ret.stderr

--- a/tests/test_http_scram.py
+++ b/tests/test_http_scram.py
@@ -1,0 +1,311 @@
+from functools import partial
+import logging
+import pytest
+import requests
+import scramp
+from unittest.mock import patch, MagicMock
+
+from conftest import PhonyConnection, mock_pool_manager
+
+from hop.auth import Auth
+from hop.http_scram import SCRAMAuth
+
+logger = logging.getLogger("hop")
+
+# Replicate the example SCRAM exchange from RFC 5802
+test_mechanism = "SCRAM-SHA-1"
+test_auth = Auth("user", "pencil", method=test_mechanism)
+test_nonce = "fyko+d2lbbFgONRv9qkxdawL"
+test_sid = "AAAABBBBCCCCDDDD"
+test_client_first = "SCRAM-SHA-1 data=biwsbj11c2VyLHI9ZnlrbytkMmxiYkZnT05Sdjlxa3hkYXdM"
+test_server_first_data = "cj1meWtvK2QybGJiRmdPTlJ2OXFreGRhd0wzcmZjTkhZSlkxWlZ2V1ZzN" \
+                         "2oscz1RU1hDUitRNnNlazhiZjkyLGk9NDA5Ng=="
+test_server_first = f"SCRAM-SHA-1 sid={test_sid},data={test_server_first_data}"
+test_client_final_data = "Yz1iaXdzLHI9ZnlrbytkMmxiYkZnT05Sdjlxa3hkYXdMM3JmY05IWUpZ" \
+                         "MVpWdldWczdqLHA9djBYOHYzQnoyVDBDSkdiSlF5RjBYK0hJNFRzPQ=="
+test_client_final = f"SCRAM-SHA-1 sid={test_sid},data={test_client_final_data}"
+test_server_final = f"sid={test_sid},data=dj1ybUY5cHFWOFM3c3VBb1pXamE0ZEpSa0ZzS1E9"
+
+
+def test_SCRAMAuth_generate_client_first():
+    with patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        cf = a._generate_client_first()
+        assert cf == test_client_first
+
+
+def request_copy(self):
+    new_request = MagicMock()
+    new_request.headers = self.headers
+    new_request.url = self.url
+    return new_request
+
+
+def test_SCRAMAuth_handle_first():
+    with patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        # matching mechanism
+        a = SCRAMAuth(test_auth)
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": test_mechanism}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        result = a._handle_first(test_resp)
+        assert "Authorization" in result.request.headers
+        assert result.request.headers["Authorization"] == test_client_first
+
+        # non-matching mechanism
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": "UNEXPECTED-MECHANISM"}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        result = a._handle_first(test_resp)
+        assert "Authorization" not in result.request.headers
+
+
+def test_SCRAMAuth_handle_final():
+    with patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        # matching mechanism
+        a = SCRAMAuth(test_auth)
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": test_server_first}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        a._generate_client_first()
+        result = a._handle_final(test_resp)
+        assert "Authorization" in result.request.headers
+        assert result.request.headers["Authorization"] == test_client_final
+
+        # non-matching mechanism
+        test_server_first_wrong_mech = f"UNEXPECTED-MECHANISM sid={test_sid}," \
+            f"data={test_server_first_data}"
+        a = SCRAMAuth(test_auth)
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": test_server_first_wrong_mech}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        a._generate_client_first()
+        result = a._handle_final(test_resp)
+        assert "Authorization" not in result.request.headers
+
+        # missing sid
+        test_server_first_no_sid = f"SCRAM-SHA-1 data={test_server_first_data}"
+        a = SCRAMAuth(test_auth)
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": test_server_first_no_sid}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        a._generate_client_first()
+        with pytest.raises(RuntimeError) as err:
+            result = a._handle_final(test_resp)
+            assert "Authorization" not in result.request.headers
+
+        # missing data
+        test_server_first_no_data = f"SCRAM-SHA-1 sid={test_sid}"
+        a = SCRAMAuth(test_auth)
+        test_resp = MagicMock()
+        test_resp.headers = {"www-authenticate": test_server_first_no_data}
+        test_resp.request.url = "http://example.com"
+        test_resp.request.headers = {}
+        test_resp.request.copy = partial(request_copy, test_resp.request)
+        a._generate_client_first()
+        with pytest.raises(RuntimeError) as err:
+            result = a._handle_final(test_resp)
+            assert "Authorization" not in result.request.headers
+
+
+def test_SCRAMAuth_check_server_final():
+    with patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        sfirst = MagicMock()
+        sfirst.headers = {"www-authenticate": test_server_first}
+        sfirst.request.url = "http://example.com"
+        sfirst.request.headers = {}
+        sfirst.request.copy = partial(request_copy, sfirst.request)
+        a._generate_client_first()
+        a._handle_final(sfirst)
+        sfinal = MagicMock()
+        sfinal.headers = {"authentication-info": test_server_final}
+        sfinal.request.url = "http://example.com"
+        sfinal.request.headers = {}
+        sfinal.request.copy = partial(request_copy, sfinal.request)
+        a._check_server_final(sfinal)
+
+        # missing sid
+        test_server_final_no_sid = "data=dj1ybUY5cHFWOFM3c3VBb1pXamE0ZEpSa0ZzS1E9"
+        a = SCRAMAuth(test_auth)
+        sfirst = MagicMock()
+        sfirst.headers = {"www-authenticate": test_server_first}
+        sfirst.request.url = "http://example.com"
+        sfirst.request.headers = {}
+        sfirst.request.copy = partial(request_copy, sfirst.request)
+        a._generate_client_first()
+        a._handle_final(sfirst)
+        sfinal = MagicMock()
+        sfinal.headers = {"authentication-info": test_server_final_no_sid}
+        sfinal.request.url = "http://example.com"
+        sfinal.request.headers = {}
+        sfinal.request.copy = partial(request_copy, sfinal.request)
+        with pytest.raises(RuntimeError):
+            a._check_server_final(sfinal)
+
+        # wrong sid
+        test_server_final_wrong_sid = "sid=XYZ,data=dj1ybUY5cHFWOFM3c3VBb1pXamE0ZEpSa0ZzS1E9"
+        a = SCRAMAuth(test_auth)
+        sfirst = MagicMock()
+        sfirst.headers = {"www-authenticate": test_server_first}
+        sfirst.request.url = "http://example.com"
+        sfirst.request.headers = {}
+        sfirst.request.copy = partial(request_copy, sfirst.request)
+        a._generate_client_first()
+        a._handle_final(sfirst)
+        sfinal = MagicMock()
+        sfinal.headers = {"authentication-info": test_server_final_wrong_sid}
+        sfinal.request.url = "http://example.com"
+        sfinal.request.headers = {}
+        sfinal.request.copy = partial(request_copy, sfinal.request)
+        with pytest.raises(RuntimeError):
+            a._check_server_final(sfinal)
+
+        # missing data
+        test_server_final_no_data = f"sid={test_sid}"
+        a = SCRAMAuth(test_auth)
+        sfirst = MagicMock()
+        sfirst.headers = {"www-authenticate": test_server_first}
+        sfirst.request.url = "http://example.com"
+        sfirst.request.headers = {}
+        sfirst.request.copy = partial(request_copy, sfirst.request)
+        a._generate_client_first()
+        a._handle_final(sfirst)
+        sfinal = MagicMock()
+        sfinal.headers = {"authentication-info": test_server_final_no_data}
+        sfinal.request.url = "http://example.com"
+        sfinal.request.headers = {}
+        sfinal.request.copy = partial(request_copy, sfinal.request)
+        with pytest.raises(RuntimeError):
+            a._check_server_final(sfinal)
+
+        # wrong data
+        test_server_final_wrong_data = f"sid={test_sid},data=dj1iYWRkYXRh"
+        a = SCRAMAuth(test_auth)
+        sfirst = MagicMock()
+        sfirst.headers = {"www-authenticate": test_server_first}
+        sfirst.request.url = "http://example.com"
+        sfirst.request.headers = {}
+        sfirst.request.copy = partial(request_copy, sfirst.request)
+        a._generate_client_first()
+        a._handle_final(sfirst)
+        sfinal = MagicMock()
+        sfinal.headers = {"authentication-info": test_server_final_wrong_data}
+        sfinal.request.url = "http://example.com"
+        sfinal.request.headers = {}
+        sfinal.request.copy = partial(request_copy, sfinal.request)
+        with pytest.raises(scramp.core.ScramException):
+            a._check_server_final(sfinal)
+
+
+def test_SCRAMAuth_integration():
+    conn = PhonyConnection([MagicMock(status=401,
+                                      headers={"WWW-Authenticate":
+                                               f'{test_mechanism} realm="realm@example.com"'}
+                                      ),
+                            MagicMock(status=401,
+                                      headers={"WWW-Authenticate": test_server_first}
+                                      ),
+                            MagicMock(status=200,
+                                      headers={"Authentication-Info": test_server_final}
+                                      )
+                            ])
+    PM = mock_pool_manager(conn)
+    with patch("requests.adapters.PoolManager", PM), \
+            patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        resp = requests.get("http://example.com", auth=a)
+        print(resp)
+        assert conn.counter == 3
+        assert "Authorization" not in conn.requests[0]["headers"]
+        assert "Authorization" in conn.requests[1]["headers"]
+        assert conn.requests[1]["headers"]["Authorization"] == test_client_first
+        assert "Authorization" in conn.requests[2]["headers"]
+        assert conn.requests[2]["headers"]["Authorization"] == test_client_final
+
+
+def test_SCRAMAuth_integration_shortcut():
+    conn = PhonyConnection([MagicMock(status=401,
+                                      headers={"WWW-Authenticate": test_server_first}
+                                      ),
+                            MagicMock(status=200,
+                                      headers={"Authentication-Info": test_server_final}
+                                      )
+                            ])
+    PM = mock_pool_manager(conn)
+    with patch("requests.adapters.PoolManager", PM), \
+            patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth, shortcut=True)
+        body = "A" * 1024
+        resp = requests.post("http://example.com", auth=a, data=body)
+        assert conn.counter == 2
+        assert "Authorization" in conn.requests[0]["headers"]
+        assert conn.requests[0]["headers"]["Authorization"] == test_client_first
+        assert conn.requests[0]["body"] is None, "No body should be sent during auth handshake"
+        assert "Authorization" in conn.requests[1]["headers"]
+        assert conn.requests[1]["headers"]["Authorization"] == test_client_final
+        assert conn.requests[1]["body"] == body, "After handshake completes, body should be sent"
+
+
+def test_SCRAMAuth_integration_auth_unnecessary():
+    conn = PhonyConnection([MagicMock(status=200,
+                                      headers={},
+                                      ),
+                            ])
+    PM = mock_pool_manager(conn)
+    with patch("requests.adapters.PoolManager", PM), \
+            patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        resp = requests.get("http://example.com", auth=a)
+        assert conn.counter == 1
+        assert "Authorization" not in conn.requests[0]["headers"]
+
+
+def test_SCRAMAuth_integration_bad_server_final():
+    conn = PhonyConnection([MagicMock(status=401,
+                                      headers={"WWW-Authenticate":
+                                               f'{test_mechanism} realm="realm@example.com"'}
+                                      ),
+                            MagicMock(status=401,
+                                      headers={"WWW-Authenticate": test_server_first}
+                                      ),
+                            MagicMock(status=200,
+                                      headers={"Authentication-Info":
+                                               f"sid={test_sid},data=dj1CYWRTZXJ2ZXJTaWduYXR1cmU="}
+                                      )
+                            ])
+    PM = mock_pool_manager(conn)
+    with patch("requests.adapters.PoolManager", PM), \
+            patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        with pytest.raises(scramp.ScramException):
+            resp = requests.get("http://example.com", auth=a)
+
+
+def test_SCRAMAuth_integration_server_fail():
+    conn = PhonyConnection([MagicMock(status=401,
+                                      headers={"WWW-Authenticate":
+                                               f'{test_mechanism} realm="realm@example.com"'}
+                                      ),
+                            MagicMock(status=500)
+                            ])
+    PM = mock_pool_manager(conn)
+    with patch("requests.adapters.PoolManager", PM), \
+            patch("secrets.token_urlsafe", MagicMock(return_value=test_nonce)):
+        a = SCRAMAuth(test_auth)
+        resp = requests.get("http://example.com", auth=a)
+        assert resp.status_code == 500
+        assert conn.counter == 2
+        assert "Authorization" not in conn.requests[0]["headers"]
+        assert "Authorization" in conn.requests[1]["headers"]
+        assert conn.requests[1]["headers"]["Authorization"] == test_client_first

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -209,3 +209,21 @@ def test_avro_multi_record_deserialization():
     # allowing multiple records should load as such
     loaded = models.AvroBlob.load(raw, single_record=False)
     assert loaded.content == original
+
+
+def test_externalmessage():
+    inputs = [
+        '{"url": "http://example.com"}',
+        b'{"url": "http://example.com"}',
+    ]
+    for input in inputs:
+        for read in [True, False]:
+            if read:
+                with patch("builtins.open", mock_open(read_data=input)):
+                    m = models.ExternalMessage.load(open("notarealfile"))
+            else:
+                m = models.ExternalMessage.load(input)
+            assert m.url == "http://example.com"
+
+    with pytest.raises(json.JSONDecodeError):
+        models.ExternalMessage.load("\tnot valid JSON\t")

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -814,7 +814,7 @@ def test_rpublisher_empty_journal(tmpdir):
     fixed_uuid = uuid4()
 
     with patch("hop.io.Stream", makeStream()) as steam_middleman, \
-            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+            patch("hop.io.uuid.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path, auth=False) as pub:
             pub.write("a message")
 
@@ -863,7 +863,7 @@ def test_rpublisher_with_auth(tmpdir):
     auth = hop.auth.Auth("user", "password")
 
     with patch("hop.io.Stream", makeStream(auth=[auth])) as steam_middleman, \
-            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+            patch("hop.io.uuid.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path, auth=True) as pub:
             pub.write("a message")
 
@@ -886,7 +886,7 @@ def test_rpublisher_immediate_send_fail(tmpdir):
     fixed_uuid = uuid4()
 
     with patch("hop.io.Stream", makeStream(immediate_failure=True)) as steam_middleman, \
-            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+            patch("hop.io.uuid.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path, auth=False) as pub:
             pub.write("a message")
 
@@ -907,7 +907,7 @@ def test_rpublisher_poll_fail(tmpdir):
     fixed_uuid = uuid4()
 
     with patch("hop.io.Stream", makeStream(poll_failure=True)) as steam_middleman, \
-            patch("hop.io.uuid4", MagicMock(return_value=fixed_uuid)):
+            patch("hop.io.uuid.uuid4", MagicMock(return_value=fixed_uuid)):
         with RobustProducer(url, journal_path=journal_path, auth=False) as pub:
             pub.write("a message")
 

--- a/tests/test_rpub.py
+++ b/tests/test_rpub.py
@@ -1185,7 +1185,7 @@ def test_rpublisher_with_auth(tmpdir):
                     pub._stream.flush()
                     break
         assert ("topic", *hop.io.Producer.pack("a message", None, auth=auth)) \
-               in pub._stream.messages_written
+            in pub._stream.messages_written
 
 
 def test_rpublisher_automatic_topic(tmpdir):
@@ -1220,7 +1220,7 @@ def test_rpublisher_automatic_topic(tmpdir):
                             journal_path=journal_path, auth=False) as pub:
             with pytest.raises(Exception):
                 pub.write("a message")
-            
+
             # messages can be written to explicitly specified topics, which need not have been
             # originally listed in the URL
             messages = {"message 1": "topicA", "message 2": "topicB", "message 3": "topicC"}


### PR DESCRIPTION
## Description

This set of commits adds the integration with the archive API (or any other compatible implementation) to offload messages which are too large to directly transmit through a Kafka topic. 

It also includes an implementation of configuration parameters for users who might want to turn this off, which involves putting in some general machinery for configuration which we didn't really have before.

Known potential issues and things which are not completely implemented:

1. If a (publishing) client checks a topic's message size limit, but the topic then has its size limit decreased, and the client tries to send a message whose size is between the old and new size limits before performing its next periodic settings check, the send will fail instead of being offloaded. Handling this case is not trivial because: 1) detecting the error would involve injecting an error callback, potentially needing to wrap the user's callback, 2) since the error would be discovered asynchronously, resending the message using offloading could alter message order, and 3) because of asynchronous handling of the error, care would be required not to repeat work inefficiently if several messages fail the same way before the first is discovered and corrective action is taken. 
2. Checking the offload server should probably be repeated periodically, so that long-running clients will not fail if the broker changes this. This would have the same problem as with message size limit decreases falling between checks, however, it would be more difficult to detect that a failure is due to stale information rather than some other cause.
3. If a topic has a very low message size limit, it may also be impossible to send the placeholder message after offloading the original. This shouldn't come up much, though, since it is difficult to imagine why anyone would configure a topic with such a low limit (of order a few hundred bytes, or less). 
4. The archive API currently does not return the ID under which a message is stored, so if the client does not label the message with an ID, it will not be able to refer to it. This is mostly not a problem for this implementation, since it generates IDs properly by default, but adds to the complexity any compatible client must have.
5. Neither the archive API nor the message offloading code in this package implements OIDC auth. This would be an issue if a broker which used OIDC wanted to add offloading. 
6. As written, the consumer only understands and accepts BSON payloads returned by the archive API. It might be nice to support fetching arbitrary data, so that users could directly generate messages which get replaced by data hosted at external public URLs? This would pose some potential problems about how data formats should be identified and mapped to model classes, however. 

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.
