### PR TITLE
Write message models to stdout in their original formats.

### DIFF
--- a/hop/subscribe.py
+++ b/hop/subscribe.py
@@ -51,4 +51,6 @@ def _main(args):
 
     with stream.open(args.url, "r", group_id=args.group_id, ignoretest=(not args.test)) as s:
         for message in s:
-            print(message, file=sys.stdout, flush=True)
+            sys.stdout.buffer.write(bytes(message))
+            if sys.stdout.buffer.isatty:
+                sys.stdout.buffer.flush()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ MESSAGE_GCN_TEXT = \
     b'COMMENTS:         The position error is statistical only, there is no systematic added.  '
 
 
-MESSAGE_BLOB = "This is a sample blob message. It is unstructured and does not require special parsing."
+MESSAGE_BLOB = b"This is a sample blob message. It is unstructured and does not require special parsing."
 
 MESSAGE_JSON = b'{"foo":"bar", "baz":5}'
 
@@ -638,7 +638,7 @@ message_parameters_dict_data = {
         "test_file": "example_voevent.xml",
         "model_text": VOEVENT_XML.encode(),
     },
-    "gcn_text_notice": {
+    "gcntextnotice": {
         "model_name": "GCNTextNotice",
         "expected_model": models.GCNTextNotice,
         "test_file": "example_gcn.txt",

--- a/tests/data/test_data/example_gcn.txt
+++ b/tests/data/test_data/example_gcn.txt
@@ -1,0 +1,28 @@
+TITLE:            GCN/AMON NOTICE
+NOTICE_DATE:      Fri 12 Apr 24 05:34:35 UT
+NOTICE_TYPE:      ICECUBE Astrotrack Bronze 
+STREAM:           25
+RUN_NUM:          139279
+EVENT_NUM:        10803235
+SRC_RA:           103.7861d {+06h 55m 09s} (J2000),
+                  104.1106d {+06h 56m 27s} (current),
+                  103.1176d {+06h 52m 28s} (1950)
+SRC_DEC:           +5.8716d {+05d 52\' 18"} (J2000),
+                   +5.8390d {+05d 50\' 20"} (current),
+                   +5.9364d {+05d 56\' 11"} (1950)
+SRC_ERROR:        69.22 [arcmin radius, stat-only, 90% containment]
+SRC_ERROR50:      26.96 [arcmin radius, stat-only, 50% containment]
+DISCOVERY_DATE:   20412 TJD;   103 DOY;   24/04/12 (yy/mm/dd)
+DISCOVERY_TIME:   20026 SOD {05:33:46.89} UT
+REVISION:         0
+ENERGY:           1.2126e+02 [TeV]
+SIGNALNESS:       3.0910e-01 [dn]
+FAR:              3.4096 [yr^-1]
+SUN_POSTN:         21.10d {+01h 24m 24s}   +8.87d {+08d 52\' 11"}
+SUN_DIST:          82.22 [deg]   Sun_angle= -5.5 [hr] (East of Sun)
+MOON_POSTN:        67.46d {+04h 29m 50s}  +26.13d {+26d 07\' 33"}
+MOON_DIST:         40.41 [deg]
+GAL_COORDS:       208.12,  3.50 [deg] galactic lon,lat of the event
+ECL_COORDS:       104.34,-16.88 [deg] ecliptic lon,lat of the event
+COMMENTS:         IceCube Bronze event.  
+COMMENTS:         The position error is statistical only, there is no systematic added.  

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -68,8 +68,8 @@ def get_model_data(model_name):
     # properly formatted, new-style messages
     {"format": "voevent",
         "content": make_message_standard(VOEvent.load(get_model_data("voevent")))},
-    {"format": "gcn_text_notice",
-        "content": make_message_standard(GCNTextNotice.load(get_model_data("gcn_text_notice")))},
+    {"format": "gcntextnotice",
+        "content": make_message_standard(GCNTextNotice.load(get_model_data("gcntextnotice")))},
     {"format": "circular",
         "content": make_message_standard(GCNCircular.load(get_model_data("circular")))},
     {"format": "json", "content": make_message_standard(JSONBlob.load(get_model_data("json")))},


### PR DESCRIPTION
The goal is that our code should be able to write models back out in their expected formats so that users can handle them normally with other tools, and so that our own model code is capable of reading them back in. 
This removes random python repr cruft from blob messages, shows GCN Text Notices in their original form, and outputs AvroBlobs as valid Avro. VOEvent is not yet handled because the importation from XML is lossy with regard to which bits are elements or attributes, and these need to be restored correctly according to the schema. 

For most models this also leads to simpler, clearer code, as `__bytes__` is responsible for serializing the data to a a flat form, and `serialize` is responsible for packaging that form together with the format name for the Kafka machinery, so most models do not need their own implementations of it.

No attempt is made in this patch to alter the fact that some models use bespoke formats for transmission over Kafka. 

## Description

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [ ] Check that CI pipeline run on this PR passes all stages.
* [ ] Review signoff by at least one developer.