### PR TITLE
Completely avoid making metadata queries to brokers when automatic_offload is set to false

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -887,7 +887,7 @@ def test_write_offload_disabled(mock_broker, mock_producer, mock_admin_client):
             with pytest.raises(KafkaException) as ex:
                 s.write_raw(*encoded_msg)
             mock_get_offload.assert_not_called()
-            assert "Unable to send message" in str(ex)
+            assert "Unable to send message" in str(ex) or "MSG_SIZE_TOO_LARGE" in str(ex)
 
 
 def check_outgoing_bson_message(data):
@@ -1667,7 +1667,6 @@ def make_mock_listing_consumer(topics=[]):
         topics exist.
     """
     def get_topics(topic=None, timeout=None):
-        nonlocal topics
         result = {}
         if topic is None:
             for topic in topics:


### PR DESCRIPTION
This provides users with a work-around for https://github.com/scimma/hop-client/issues/234

## Checklist

* [ ] ~All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)~
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.

NOTE: If this PR relates to a release, open and reference an issue with the Release checklist template.
