### PR TITLE
Improve handling of high message volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint :
 
 .PHONY: format
 format :
-	autopep8 --recursive --in-place hop tests
+	autopep8 --recursive --in-place --max-line-length=100 hop tests
 
 .PHONY: doc
 doc :

--- a/doc/user/stream.rst
+++ b/doc/user/stream.rst
@@ -109,6 +109,19 @@ In fact, when opening a stream for writing, it is not necessary for the target U
 a topic at all; if it does not, the topic to which to publish must always be specified when
 calling :code:`write()`.
 
+Message Publication Timeout
+------------------------------
+
+The :code:`produce_timeout` argument to :code:`stream.open` corresponds to the librdkafka
+:code:`message.timeout.ms` parameter. This setting is useful for when messages must be delivered
+within a specified latency, and failure to do so should be treated as an error.
+
+For many uses, this is not necessary, and so the default value is zero, disabling the timeout
+mechanism. In particular, since the timeout counts time from when the message is queued to be
+published (with :code:`write` to when), messages can time out due to waiting for messages queued
+ahead of them to be delivered. This can most commonly become an issue when publishing significant
+numbers of relatively large messages, for which transmission is bandwidth limited.
+
 Committing Messages Manually
 ------------------------------
 

--- a/hop/io.py
+++ b/hop/io.py
@@ -1096,6 +1096,12 @@ class Producer:
 
     def flush(self, timeout: Optional[timedelta] = None):
         """Request that any messages locally queued for sending be sent immediately.
+
+        Args:
+            timeout: The length of time to wait for messages to send.
+                     Defaults to the produce_timeout.
+        Returns:
+            The number of messages still queued locally to be sent.
         """
         if timeout is None:
             timeout = self.produce_timeout

--- a/hop/io.py
+++ b/hop/io.py
@@ -1122,7 +1122,10 @@ class Producer:
         """Wait for enqueued messages to be written and shut down.
 
         """
-        logger.info("closing connection")
+        if sum([r.producer.queued_message_count() for r in self.producers.values()]) > 0:
+            logger.info("closing connection after queued messages send")
+        else:
+            logger.info("closing connection")
         still_queued = 0
         for p_record in self.producers.values():
             still_queued += p_record.producer.close(self.produce_timeout)

--- a/hop/io.py
+++ b/hop/io.py
@@ -88,7 +88,9 @@ class Stream(object):
         # do not leak back into the cached data.
         return load_config()
 
-    def open(self, url, mode="r", group_id=None, ignoretest=True, **kwargs):
+    def open(self, url, mode="r", group_id=None, ignoretest=True,
+             produce_timeout=timedelta(seconds=0.0),
+             **kwargs):
         """Opens a connection to an event stream.
 
         Args:
@@ -98,6 +100,11 @@ class Stream(object):
                       Generated automatically if not specified.
             ignoretest: When True, read mode will silently discard
                         test messages.
+            produce_timeout: A limit on the time within which each
+                             published message must be sent. If zero,
+                             no limit is applied, and closing the
+                             producer will wait indefinitely for all
+                             queued messages to send.
 
         Returns:
             An open connection to the client, either a :class:`Producer` instance
@@ -136,7 +143,8 @@ class Stream(object):
                 topics = []
             if group_id is not None:
                 warnings.warn("group ID has no effect when opening a stream in write mode")
-            return Producer(broker_addresses, topics, auth=credential, **kwargs)
+            return Producer(broker_addresses, topics, auth=credential,
+                            produce_timeout=produce_timeout, **kwargs)
         elif mode == "r":
             if topics is None or len(topics) == 0:
                 raise ValueError("no topic(s) specified in kafka URL")

--- a/hop/publish.py
+++ b/hop/publish.py
@@ -32,7 +32,7 @@ def _add_parser_args(parser):
     parser.add_argument(
         "--timeout",
         type=float,
-        default=10.0,
+        default=0.0,
         help="Time to wait for a message to be sent and acknowledged, in seconds."
              "Zero for no timeout."
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "adc-streaming >= 2.5.0",
+    "adc-streaming >= 2.6.0",
     "bson",
     "fastavro >= 1.4.0",
     "pluggy >= 0.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "adc-streaming >= 2.6.0",
     "bson",
     "fastavro >= 1.4.0",
+    "requests",
     "pluggy >= 0.11",
     "scramp",
     "toml >= 0.9.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,6 +426,9 @@ class ProducerBrokerWrapper:
     def __len__(self):
         return len(self._delayed)
 
+    def queued_message_count(self):
+        return len(self._delayed)
+
     def flush(self, timeout=None):
         """Simulate time passing, possibly allowing delayed messages to send"""
         if self._delay_sending > 0.0:


### PR DESCRIPTION
## Description

- Support a timeout for io.Producer.flush and close, and use produce_timeout as the default
- Expose the timeout as a parameter for the CLI publish command

This fixes, or enables the user to work around, the obnoxious failure modes of publishing, particularly of `hop publish`, to exit before all messages have been transmitted to the broker. 

Depends on [adc-streaming commit f710c8889c9656cb420f9ec66162be21127efb68](https://github.com/astronomy-commons/adc-streaming/pull/73)

## Checklist

* [x] All new functions and classes are documented and adhere to Google doc style (3.8.3-3.8.6 of [this](http://google.github.io/styleguide/pyguide.html#383-functions-and-methods) document)
* [x] Add/update sphinx documentation with any relevant changes.
* [x] Add/update pytest-style tests in `/tests`, ensuring sufficient code coverage.
* [x] `make test` runs without errors.
* [x] `make lint` doesn't give any warnings.
* [x] `make format` doesn't give any code formatting suggestions.
* [x] `make doc` runs without errors and generated docs render correctly.
* [x] Check that CI pipeline run on this PR passes all stages.
* [x] Review signoff by at least one developer.